### PR TITLE
Add Source : KvSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ PointerField contains:&{BoolField:true FloatField:55.55}
 
 ## Full example : 
 [Tagoæl](https://github.com/debovema/tagoael) is a trivial example which shows how Stært can be use.
-This funny golang progam takes its configuration form both TOML and Flaeg sources to display messages.
+This funny golang progam takes its configuration from both TOML and Flaeg sources to display messages.
 ```shell
 $ ./tagoael -h
 tagoæl is an enhanced Hello World program to display messages with
@@ -191,7 +191,7 @@ KvSource impement Source:
 ```go
 type KvSource struct {
 	store.Store
-	Prefix string // like this "prefix/" (wiht the /)
+	Prefix string // like this "prefix" (witout the /)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Just call LoadConfig function :
     if err != nil {
 		//OOPS
 	}
-	//DO WATH YOU WANT WITH loadedConfig 
+	//DO WHAT YOU WANT WITH loadedConfig 
 	//OR CALL RUN FUNC
 ``` 
 
@@ -168,20 +168,20 @@ Flags:
         -n, --numbertodisplay                              Number of messages to display (default "1000")
         -h, --help                                         Print Help (this message) and exit
 ```
-Thanks you @debovema for this work :)
+Thank you [@debovema](https://github.com/debovema) for this work :)
 
 ## KvStore
-As like as Flæg and Toml sources, the configuration structure can be loaded from a Key-Value Store.
+As with Flæg and Toml sources, the configuration structure can be loaded from a Key-Value Store.
 The package [libkv](https://github.com/docker/libkv) provides connection to many KV Store like `Consul`, `Etcd` or `Zookeeper`.
 
 The whole configuration structure is stored, using architecture like this pattern :
  - Key : `<prefix1>/<prefix2>/.../<fieldNameLevel1>/<fieldNameLevel2>/.../<fieldName>`
  - Value : `<value>`
  
-It handels :
- - All [mapstructure](https://github.com/mitchellh/mapstructure) features(`bool`, `int`, ... , Squashed Embeded Sub `struct`, Pointer).
+It handles :
+ - All [mapstructure](https://github.com/mitchellh/mapstructure) features(`bool`, `int`, ... , Squashed Embedded Sub `struct`, Pointer).
  - Maps with pattern : `.../<MapFieldName>/<mapKey>` -> `<mapValue>` (Struct as key not supported)
- - Slices (and Arraies) with pattern : `.../<SliceFieldName>/<SliceIndex>` -> `<value>`
+ - Slices (and Arrays) with pattern : `.../<SliceFieldName>/<SliceIndex>` -> `<value>`
 
 Note : Hopefully, we provide the function `StoreConfig` to store your configuration structure ;)
 
@@ -196,7 +196,7 @@ type KvSource struct {
 ```
 
 ### Initialize 
-It can be Initialize like this :
+It can be initialized like this :
 ```go
 	kv, err := staert.KvSource(backend store.Backend, addrs []string, options *store.Config, prefix string)
 ```
@@ -206,11 +206,11 @@ You can directly load data from the KV Store into the config structure (given by
 ```go
 	config := &ConfigStruct{} // Here your configuration structure by reference
 	err := kv.Parse(config)
-	//DO WATH YOU WANT WITH config
+	//DO WHAT YOU WANT WITH config
 ```
 
 ### Add to Stært sources
-Or you can add this source to Stært, as like as other sources
+Or you can add this source to Stært, as with other sources
 ```go
 	s.AddSource(kv)
 ```

--- a/kv.go
+++ b/kv.go
@@ -13,22 +13,22 @@ import (
 	"strings"
 )
 
-// KvSource impement Source
-// It handels all mapstructure features(Squashed Embeded Sub-Structures, Maps, Pointers)
-// It support Slices (and maybe Arraies). They must be sort in the KvStore like this :
+// KvSource implements Source
+// It handles all mapstructure features(Squashed Embeded Sub-Structures, Maps, Pointers)
+// It supports Slices (and maybe Arraies). They must be sorted in the KvStore like this :
 // Key : ".../[sliceIndex]" -> Value
 type KvSource struct {
 	store.Store
 	Prefix string // like this "prefix" (without the /)
 }
 
-// NewKvSource creats a new KvSource
+// NewKvSource creates a new KvSource
 func NewKvSource(backend store.Backend, addrs []string, options *store.Config, prefix string) (*KvSource, error) {
 	store, err := libkv.NewStore(backend, addrs, options)
 	return &KvSource{Store: store, Prefix: prefix}, err
 }
 
-// Parse use libkv and mapstructure to fill the structure
+// Parse uses libkv and mapstructure to fill the structure
 func (kv *KvSource) Parse(cmd *flaeg.Command) (*flaeg.Command, error) {
 	err := kv.LoadConfig(cmd.Config)
 	if err != nil {
@@ -37,7 +37,7 @@ func (kv *KvSource) Parse(cmd *flaeg.Command) (*flaeg.Command, error) {
 	return cmd, nil
 }
 
-// LoadConfig load data from the KV Store into the config structure (given by reference)
+// LoadConfig loads data from the KV Store into the config structure (given by reference)
 func (kv *KvSource) LoadConfig(config interface{}) error {
 	pairs, err := kv.List(kv.Prefix)
 	if err != nil {
@@ -78,7 +78,7 @@ func generateMapstructure(pairs []*store.KVPair, prefix string) (map[string]inte
 }
 
 func processKV(key string, v string, raw map[string]interface{}) (map[string]interface{}, error) {
-	// Determine what map we're writing the value to. We split by '/'
+	// Determine which map we're writing the value to. We split by '/'
 	// to determine any sub-maps that need to be created.
 	m := raw
 	children := strings.Split(key, "/")

--- a/kv.go
+++ b/kv.go
@@ -1,0 +1,36 @@
+package staert
+
+import (
+	"fmt"
+	"strings"
+)
+
+func generateMapstructure(input map[string]string, prefix string) (map[string]interface{}, error) {
+	raw := make(map[string]interface{})
+	for k, v := range input {
+		// Trim the prefix off our key first
+		key := strings.TrimPrefix(k, prefix)
+
+		// Determine what map we're writing the value to. We split by '/'
+		// to determine any sub-maps that need to be created.
+		m := raw
+		children := strings.Split(key, "/")
+		if len(children) > 0 {
+			key = children[len(children)-1]
+			children = children[:len(children)-1]
+			for _, child := range children {
+				if m[child] == nil {
+					m[child] = make(map[string]interface{})
+				}
+				subm, ok := m[child].(map[string]interface{})
+				if !ok {
+					return nil, fmt.Errorf("child is both a data item and dir: %s", child)
+				}
+				m = subm
+			}
+
+		}
+		m[key] = string(v)
+	}
+	return raw, nil
+}

--- a/kv.go
+++ b/kv.go
@@ -19,7 +19,7 @@ import (
 // Key : ".../[sliceIndex]" -> Value
 type KvSource struct {
 	store.Store
-	Prefix string // like this "prefix/" (wiht the /)
+	Prefix string // like this "prefix" (without the /)
 }
 
 // NewKvSource creats a new KvSource
@@ -67,7 +67,7 @@ func generateMapstructure(pairs []*store.KVPair, prefix string) (map[string]inte
 	raw := make(map[string]interface{})
 	for _, p := range pairs {
 		// Trim the prefix off our key first
-		key := strings.TrimPrefix(p.Key, prefix)
+		key := strings.TrimPrefix(p.Key, prefix+"/")
 		raw, err := processKV(key, string(p.Value), raw)
 		if err != nil {
 			return raw, err

--- a/kv.go
+++ b/kv.go
@@ -2,35 +2,82 @@ package staert
 
 import (
 	"fmt"
+	"github.com/docker/libkv/store"
+	"reflect"
+	"sort"
+	"strconv"
 	"strings"
 )
 
-func generateMapstructure(input map[string]string, prefix string) (map[string]interface{}, error) {
+func generateMapstructure(pairs []*store.KVPair, prefix string) (map[string]interface{}, error) {
 	raw := make(map[string]interface{})
-	for k, v := range input {
+	for _, p := range pairs {
 		// Trim the prefix off our key first
-		key := strings.TrimPrefix(k, prefix)
-
-		// Determine what map we're writing the value to. We split by '/'
-		// to determine any sub-maps that need to be created.
-		m := raw
-		children := strings.Split(key, "/")
-		if len(children) > 0 {
-			key = children[len(children)-1]
-			children = children[:len(children)-1]
-			for _, child := range children {
-				if m[child] == nil {
-					m[child] = make(map[string]interface{})
-				}
-				subm, ok := m[child].(map[string]interface{})
-				if !ok {
-					return nil, fmt.Errorf("child is both a data item and dir: %s", child)
-				}
-				m = subm
-			}
-
+		key := strings.TrimPrefix(p.Key, prefix)
+		raw, err := processKV(key, string(p.Value), raw)
+		if err != nil {
+			return raw, err
 		}
-		m[key] = string(v)
+
 	}
 	return raw, nil
+}
+
+func processKV(key string, v string, raw map[string]interface{}) (map[string]interface{}, error) {
+	// Determine what map we're writing the value to. We split by '/'
+	// to determine any sub-maps that need to be created.
+	m := raw
+	children := strings.Split(key, "/")
+	if len(children) > 0 {
+		key = children[len(children)-1]
+		children = children[:len(children)-1]
+		for _, child := range children {
+			if m[child] == nil {
+				m[child] = make(map[string]interface{})
+			}
+			subm, ok := m[child].(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("child is both a data item and dir: %s", child)
+			}
+			m = subm
+		}
+
+	}
+	m[key] = string(v)
+
+	return raw, nil
+}
+
+func decodeHookSlice(fromType reflect.Type, toType reflect.Type, data interface{}) (interface{}, error) {
+	if toType.Kind() == reflect.Slice {
+		if fromType.Kind() == reflect.Map {
+			// Type assertion
+			dataMap, ok := data.(map[string]interface{})
+			if !ok {
+				return data, fmt.Errorf("input data is not a map : %#v", data)
+			}
+			// Sorting map
+			indexes := make([]int, len(dataMap))
+			i := 0
+			for k := range dataMap {
+				ind, err := strconv.Atoi(k)
+				if err != nil {
+					return dataMap, err
+				}
+				indexes[i] = ind
+				i++
+			}
+			sort.Ints(indexes)
+			// Building slice
+			dataOutput := make([]interface{}, i)
+			i = 0
+			for _, k := range indexes {
+				dataOutput[i] = dataMap[strconv.Itoa(k)]
+				i++
+			}
+
+			return dataOutput, nil
+		}
+	}
+	return data, nil
 }

--- a/kv_test.go
+++ b/kv_test.go
@@ -1,18 +1,25 @@
 package staert
 
 import (
+	"github.com/docker/libkv/store"
 	"reflect"
 	"testing"
 )
 
 func TestGenerateMapstructureBasic(t *testing.T) {
-	input := map[string]string{
-		"test/addr":       "foo",
-		"test/child/data": "bar",
+	moke := []*store.KVPair{
+		&store.KVPair{
+			Key:   "test/addr",
+			Value: []byte("foo"),
+		},
+		&store.KVPair{
+			Key:   "test/child/data",
+			Value: []byte("bar"),
+		},
 	}
 	prefix := "test/"
 
-	output, err := generateMapstructure(input, prefix)
+	output, err := generateMapstructure(moke, prefix)
 	if err != nil {
 		t.Fatalf("Error :%s", err)
 	}
@@ -29,14 +36,23 @@ func TestGenerateMapstructureBasic(t *testing.T) {
 }
 
 func TestGenerateMapstructureTrivialMap(t *testing.T) {
-	input := map[string]string{
-		"test/vfoo":       "foo",
-		"test/vother/foo": "foo",
-		"test/vother/bar": "bar",
+	moke := []*store.KVPair{
+		&store.KVPair{
+			Key:   "test/vfoo",
+			Value: []byte("foo"),
+		},
+		&store.KVPair{
+			Key:   "test/vother/foo",
+			Value: []byte("foo"),
+		},
+		&store.KVPair{
+			Key:   "test/vother/bar",
+			Value: []byte("bar"),
+		},
 	}
 	prefix := "test/"
 
-	output, err := generateMapstructure(input, prefix)
+	output, err := generateMapstructure(moke, prefix)
 	if err != nil {
 		t.Fatalf("Error :%s", err)
 	}
@@ -54,15 +70,27 @@ func TestGenerateMapstructureTrivialMap(t *testing.T) {
 }
 
 func TestGenerateMapstructureTrivialSlice(t *testing.T) {
-	input := map[string]string{
-		"test/vfoo":     "foo",
-		"test/vother/0": "foo",
-		"test/vother/1": "bar",
-		"test/vother/2": "bar",
+	moke := []*store.KVPair{
+		&store.KVPair{
+			Key:   "test/vfoo",
+			Value: []byte("foo"),
+		},
+		&store.KVPair{
+			Key:   "test/vother/0",
+			Value: []byte("foo"),
+		},
+		&store.KVPair{
+			Key:   "test/vother/1",
+			Value: []byte("bar1"),
+		},
+		&store.KVPair{
+			Key:   "test/vother/2",
+			Value: []byte("bar2"),
+		},
 	}
 	prefix := "test/"
 
-	output, err := generateMapstructure(input, prefix)
+	output, err := generateMapstructure(moke, prefix)
 	if err != nil {
 		t.Fatalf("Error :%s", err)
 	}
@@ -71,8 +99,8 @@ func TestGenerateMapstructureTrivialSlice(t *testing.T) {
 		"vfoo": "foo",
 		"vother": map[string]interface{}{
 			"0": "foo",
-			"1": "bar",
-			"2": "bar",
+			"1": "bar1",
+			"2": "bar2",
 		},
 	}
 	if !reflect.DeepEqual(check, output) {
@@ -81,16 +109,31 @@ func TestGenerateMapstructureTrivialSlice(t *testing.T) {
 }
 
 func TestGenerateMapstructureNotTrivialSlice(t *testing.T) {
-	input := map[string]string{
-		"test/vfoo":          "foo",
-		"test/vother/0/foo1": "bar",
-		"test/vother/0/foo2": "bar",
-		"test/vother/1/bar1": "foo",
-		"test/vother/1/bar2": "foo",
+	moke := []*store.KVPair{
+		&store.KVPair{
+			Key:   "test/vfoo",
+			Value: []byte("foo"),
+		},
+		&store.KVPair{
+			Key:   "test/vother/0/foo1",
+			Value: []byte("bar"),
+		},
+		&store.KVPair{
+			Key:   "test/vother/0/foo2",
+			Value: []byte("bar"),
+		},
+		&store.KVPair{
+			Key:   "test/vother/1/bar1",
+			Value: []byte("foo"),
+		},
+		&store.KVPair{
+			Key:   "test/vother/1/bar2",
+			Value: []byte("foo"),
+		},
 	}
 	prefix := "test/"
 
-	output, err := generateMapstructure(input, prefix)
+	output, err := generateMapstructure(moke, prefix)
 	if err != nil {
 		t.Fatalf("Error :%s", err)
 	}
@@ -111,4 +154,45 @@ func TestGenerateMapstructureNotTrivialSlice(t *testing.T) {
 	if !reflect.DeepEqual(check, output) {
 		t.Fatalf("Expected %#v\nGot %#v", check, output)
 	}
+}
+
+func TestDecodeHookSlice(t *testing.T) {
+	type BasicStruct struct {
+		Bar1 string
+		Bar2 string
+	}
+	type SliceStruct []BasicStruct
+	type Test struct {
+		Vfoo   string
+		Vother SliceStruct
+	}
+	data := map[string]interface{}{
+		"10": map[string]interface{}{
+			"bar1": "bar1",
+			"bar2": "bar2",
+		},
+		"2": map[string]interface{}{
+			"bar1": "foo1",
+			"bar2": "foo2",
+		},
+	}
+	output, err := decodeHookSlice(reflect.TypeOf(data), reflect.TypeOf([]string{}), data)
+	if err != nil {
+		t.Fatalf("Error : %s", err)
+	}
+
+	check := []interface{}{
+		map[string]interface{}{
+			"bar1": "foo1",
+			"bar2": "foo2",
+		},
+		map[string]interface{}{
+			"bar1": "bar1",
+			"bar2": "bar2",
+		},
+	}
+	if !reflect.DeepEqual(check, output) {
+		t.Fatalf("Expected %#v\nGot %#v", check, output)
+	}
+
 }

--- a/kv_test.go
+++ b/kv_test.go
@@ -1,9 +1,15 @@
 package staert
 
 import (
+	"encoding/json"
+	"errors"
+	"github.com/containous/flaeg"
 	"github.com/docker/libkv/store"
+	"github.com/mitchellh/mapstructure"
 	"reflect"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestGenerateMapstructureBasic(t *testing.T) {
@@ -157,15 +163,6 @@ func TestGenerateMapstructureNotTrivialSlice(t *testing.T) {
 }
 
 func TestDecodeHookSlice(t *testing.T) {
-	type BasicStruct struct {
-		Bar1 string
-		Bar2 string
-	}
-	type SliceStruct []BasicStruct
-	type Test struct {
-		Vfoo   string
-		Vother SliceStruct
-	}
 	data := map[string]interface{}{
 		"10": map[string]interface{}{
 			"bar1": "bar1",
@@ -176,7 +173,7 @@ func TestDecodeHookSlice(t *testing.T) {
 			"bar2": "foo2",
 		},
 	}
-	output, err := decodeHookSlice(reflect.TypeOf(data), reflect.TypeOf([]string{}), data)
+	output, err := decodeHook(reflect.TypeOf(data), reflect.TypeOf([]string{}), data)
 	if err != nil {
 		t.Fatalf("Error : %s", err)
 	}
@@ -193,6 +190,409 @@ func TestDecodeHookSlice(t *testing.T) {
 	}
 	if !reflect.DeepEqual(check, output) {
 		t.Fatalf("Expected %#v\nGot %#v", check, output)
+	}
+
+}
+
+type BasicStruct struct {
+	Bar1 string
+	Bar2 string
+}
+type SliceStruct []BasicStruct
+type Test struct {
+	Vfoo   string
+	Vother SliceStruct
+}
+
+func TestIntegrationMapstructureWithDecodeHook(t *testing.T) {
+	input := map[string]interface{}{
+		"vfoo": "foo",
+		"vother": map[string]interface{}{
+			"10": map[string]interface{}{
+				"bar1": "bar1",
+				"bar2": "bar2",
+			},
+			"2": map[string]interface{}{
+				"bar1": "foo1",
+				"bar2": "foo2",
+			},
+		},
+	}
+	var config Test
+
+	//test
+	configDecoder := &mapstructure.DecoderConfig{
+		Metadata:         nil,
+		Result:           &config,
+		WeaklyTypedInput: true,
+		DecodeHook:       decodeHook,
+	}
+	decoder, err := mapstructure.NewDecoder(configDecoder)
+	if err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+	if err := decoder.Decode(input); err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+
+	//check
+	check := Test{
+		Vfoo: "foo",
+		Vother: SliceStruct{
+			BasicStruct{
+				Bar1: "foo1",
+				Bar2: "foo2",
+			},
+			BasicStruct{
+				Bar1: "bar1",
+				Bar2: "bar2",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(check, config) {
+		t.Fatalf("Expected %#v\nGot %#v", check, config)
+	}
+}
+
+// Extremely limited mock store so we can test initialization
+type Mock struct {
+	Error           bool
+	KVPairs         []*store.KVPair
+	WatchTreeMethod func() <-chan []*store.KVPair
+}
+
+func (s *Mock) Put(key string, value []byte, opts *store.WriteOptions) error {
+	return errors.New("Put not supported")
+}
+
+func (s *Mock) Get(key string) (*store.KVPair, error) {
+	if s.Error {
+		return nil, errors.New("Error")
+	}
+	for _, kvPair := range s.KVPairs {
+		if kvPair.Key == key {
+			return kvPair, nil
+		}
+	}
+	return nil, nil
+}
+
+func (s *Mock) Delete(key string) error {
+	return errors.New("Delete not supported")
+}
+
+// Exists mock
+func (s *Mock) Exists(key string) (bool, error) {
+	return false, errors.New("Exists not supported")
+}
+
+// Watch mock
+func (s *Mock) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+	return nil, errors.New("Watch not supported")
+}
+
+// WatchTree mock
+func (s *Mock) WatchTree(prefix string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+	return s.WatchTreeMethod(), nil
+}
+
+// NewLock mock
+func (s *Mock) NewLock(key string, options *store.LockOptions) (store.Locker, error) {
+	return nil, errors.New("NewLock not supported")
+}
+
+// List mock
+func (s *Mock) List(prefix string) ([]*store.KVPair, error) {
+	if s.Error {
+		return nil, errors.New("Error")
+	}
+	kv := []*store.KVPair{}
+	for _, kvPair := range s.KVPairs {
+		if strings.HasPrefix(kvPair.Key, prefix) {
+			kv = append(kv, kvPair)
+		}
+	}
+	return kv, nil
+}
+
+// DeleteTree mock
+func (s *Mock) DeleteTree(prefix string) error {
+	return errors.New("DeleteTree not supported")
+}
+
+// AtomicPut mock
+func (s *Mock) AtomicPut(key string, value []byte, previous *store.KVPair, opts *store.WriteOptions) (bool, *store.KVPair, error) {
+	return false, nil, errors.New("AtomicPut not supported")
+}
+
+// AtomicDelete mock
+func (s *Mock) AtomicDelete(key string, previous *store.KVPair) (bool, error) {
+	return false, errors.New("AtomicDelete not supported")
+}
+
+// Close mock
+func (s *Mock) Close() {
+	return
+}
+
+func TestKvSourceEmpty(t *testing.T) {
+	//Init
+	config := &StructPtr{
+		PtrStruct1: &Struct1{
+			S1Int:    1,
+			S1String: "S1StringInitConfig",
+		},
+		DurationField: time.Second,
+	}
+
+	//Test
+	rootCmd := &flaeg.Command{
+		Name:                  "test",
+		Description:           "description test",
+		Config:                config,
+		DefaultPointersConfig: config,
+		Run: func() error { return nil },
+	}
+	s := NewStaert(rootCmd)
+	kv := &KvSource{
+		&Mock{
+			KVPairs: []*store.KVPair{},
+		},
+		"test/",
+	}
+	s.AddSource(kv)
+
+	_, err := s.LoadConfig()
+	if err != nil {
+		t.Fatalf("Error %s", err)
+	}
+
+	//Check
+	check := &StructPtr{
+		PtrStruct1: &Struct1{
+			S1Int:    1,
+			S1String: "S1StringInitConfig",
+		},
+		DurationField: time.Second,
+	}
+
+	if !reflect.DeepEqual(check, rootCmd.Config) {
+		t.Fatalf("\nexpected\t: %+v\ngot\t\t\t: %+v\n", check, rootCmd.Config)
+	}
+}
+func TestGenerateMapstructureTrivial(t *testing.T) {
+	input := []*store.KVPair{
+		{
+			Key:   "test/ptrstruct1/s1int",
+			Value: []byte("28"),
+		},
+		{
+			Key:   "test/durationfield",
+			Value: []byte("28"),
+		},
+	}
+	prefix := "test/"
+	output, err := generateMapstructure(input, prefix)
+	if err != nil {
+		t.Fatalf("Error :%s", err)
+	}
+	//check
+	check := map[string]interface{}{
+		"durationfield": "28",
+		"ptrstruct1": map[string]interface{}{
+			"s1int": "28",
+		},
+	}
+	if !reflect.DeepEqual(check, output) {
+		printResult, err := json.Marshal(output)
+		if err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		printCheck, err := json.Marshal(check)
+		if err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		t.Fatalf("\nexpected\t: %s\ngot\t\t\t: %s\n", printCheck, printResult)
+	}
+
+}
+func TestIntegrationMapstructureWithDecodeHookPointer(t *testing.T) {
+	mapstruct := map[string]interface{}{
+		"durationfield": "28",
+		"ptrstruct1": map[string]interface{}{
+			"s1int": "28",
+		},
+	}
+	config := StructPtr{}
+
+	//test
+	configDecoder := &mapstructure.DecoderConfig{
+		Metadata:         nil,
+		Result:           &config,
+		WeaklyTypedInput: true,
+		DecodeHook:       decodeHook,
+		//TODO : ZeroFields:       false, doesn't work
+
+	}
+	decoder, err := mapstructure.NewDecoder(configDecoder)
+	if err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+	if err := decoder.Decode(mapstruct); err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+
+	//check
+	check := StructPtr{
+		PtrStruct1: &Struct1{
+			S1Int: 28,
+		},
+		DurationField: time.Nanosecond * 28,
+	}
+
+	if !reflect.DeepEqual(check, config) {
+		printResult, err := json.Marshal(config)
+		if err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		printCheck, err := json.Marshal(check)
+		if err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		t.Fatalf("\nexpected\t: %s\ngot\t\t\t: %s\n", printCheck, printResult)
+	}
+}
+func TestIntegrationMapstructureInitedPtrReset(t *testing.T) {
+	mapstruct := map[string]interface{}{
+		// "durationfield": "28",
+		"ptrstruct1": map[string]interface{}{
+			"s1int": "24",
+		},
+	}
+	config := StructPtr{
+		PtrStruct1: &Struct1{
+			S1Int:    1,
+			S1String: "S1StringInitConfig",
+		},
+		DurationField: time.Nanosecond * 28,
+	}
+
+	//test
+	configDecoder := &mapstructure.DecoderConfig{
+		Metadata:         nil,
+		Result:           &config,
+		WeaklyTypedInput: true,
+		DecodeHook:       decodeHook,
+	}
+	decoder, err := mapstructure.NewDecoder(configDecoder)
+	if err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+	if err := decoder.Decode(mapstruct); err != nil {
+		t.Fatalf("got an err: %s", err.Error())
+	}
+
+	//check
+	check := StructPtr{
+		PtrStruct1: &Struct1{
+			S1Int: 24,
+		},
+		DurationField: time.Nanosecond * 28,
+	}
+
+	if !reflect.DeepEqual(check, config) {
+		printResult, err := json.Marshal(config)
+		if err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		printCheck, err := json.Marshal(check)
+		if err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		t.Fatalf("\nexpected\t: %s\ngot\t\t\t: %s\n", printCheck, printResult)
+	}
+}
+func TestParseKvSourceTrivial(t *testing.T) {
+	//Init
+	config := StructPtr{}
+
+	//Test
+	rootCmd := &flaeg.Command{
+		Name:                  "test",
+		Description:           "description test",
+		Config:                &config,
+		DefaultPointersConfig: &config,
+		Run: func() error { return nil },
+	}
+	kv := &KvSource{
+		&Mock{
+			KVPairs: []*store.KVPair{
+				{
+					Key:   "test/ptrstruct1/s1int",
+					Value: []byte("28"),
+				},
+				{
+					Key:   "test/durationfield",
+					Value: []byte("28"),
+				},
+			},
+		},
+		"test/",
+	}
+	if _, err := kv.Parse(rootCmd); err != nil {
+		t.Fatalf("Error %s", err)
+	}
+
+	//Check
+	check := &StructPtr{
+		PtrStruct1: &Struct1{
+			S1Int: 28,
+		},
+		DurationField: time.Nanosecond * 28,
+	}
+
+	if !reflect.DeepEqual(check, rootCmd.Config) {
+		printResult, err := json.Marshal(rootCmd.Config)
+		if err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		printCheck, err := json.Marshal(check)
+		if err != nil {
+			t.Fatalf("error: %s", err)
+		}
+		t.Fatalf("\nexpected\t: %s\ngot\t\t\t: %s\n", printCheck, printResult)
+	}
+}
+func TestIntegrationMockList(t *testing.T) {
+	kv := &Mock{
+		KVPairs: []*store.KVPair{
+			{
+				Key:   "test/ptrstruct1/s1int",
+				Value: []byte("28"),
+			},
+			{
+				Key:   "test/durationfield",
+				Value: []byte("28"),
+			},
+		},
+	}
+	pairs, err := kv.List("test/")
+	if err != nil {
+		t.Fatalf("Error : %s", err)
+	}
+	//check
+	if len(pairs) != 2 {
+		t.Fatalf("Expected 2 pairs got %d", len(pairs))
+	}
+	check := map[string][]byte{
+		"test/ptrstruct1/s1int": []byte("28"),
+		"test/durationfield":    []byte("28"),
+	}
+	for _, p := range pairs {
+		if !reflect.DeepEqual(p.Value, check[p.Key]) {
+			t.Fatalf("key %s expected value %s got %s", p.Key, check[p.Key], p.Value)
+		}
 	}
 
 }

--- a/kv_test.go
+++ b/kv_test.go
@@ -1,0 +1,114 @@
+package staert
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGenerateMapstructureBasic(t *testing.T) {
+	input := map[string]string{
+		"test/addr":       "foo",
+		"test/child/data": "bar",
+	}
+	prefix := "test/"
+
+	output, err := generateMapstructure(input, prefix)
+	if err != nil {
+		t.Fatalf("Error :%s", err)
+	}
+	//check
+	check := map[string]interface{}{
+		"addr": "foo",
+		"child": map[string]interface{}{
+			"data": "bar",
+		},
+	}
+	if !reflect.DeepEqual(check, output) {
+		t.Fatalf("Expected %+v\nGot %+v", check, output)
+	}
+}
+
+func TestGenerateMapstructureTrivialMap(t *testing.T) {
+	input := map[string]string{
+		"test/vfoo":       "foo",
+		"test/vother/foo": "foo",
+		"test/vother/bar": "bar",
+	}
+	prefix := "test/"
+
+	output, err := generateMapstructure(input, prefix)
+	if err != nil {
+		t.Fatalf("Error :%s", err)
+	}
+	//check
+	check := map[string]interface{}{
+		"vfoo": "foo",
+		"vother": map[string]interface{}{
+			"foo": "foo",
+			"bar": "bar",
+		},
+	}
+	if !reflect.DeepEqual(check, output) {
+		t.Fatalf("Expected %#v\nGot %#v", check, output)
+	}
+}
+
+func TestGenerateMapstructureTrivialSlice(t *testing.T) {
+	input := map[string]string{
+		"test/vfoo":     "foo",
+		"test/vother/0": "foo",
+		"test/vother/1": "bar",
+		"test/vother/2": "bar",
+	}
+	prefix := "test/"
+
+	output, err := generateMapstructure(input, prefix)
+	if err != nil {
+		t.Fatalf("Error :%s", err)
+	}
+	//check
+	check := map[string]interface{}{
+		"vfoo": "foo",
+		"vother": map[string]interface{}{
+			"0": "foo",
+			"1": "bar",
+			"2": "bar",
+		},
+	}
+	if !reflect.DeepEqual(check, output) {
+		t.Fatalf("Expected %#v\nGot %#v", check, output)
+	}
+}
+
+func TestGenerateMapstructureNotTrivialSlice(t *testing.T) {
+	input := map[string]string{
+		"test/vfoo":          "foo",
+		"test/vother/0/foo1": "bar",
+		"test/vother/0/foo2": "bar",
+		"test/vother/1/bar1": "foo",
+		"test/vother/1/bar2": "foo",
+	}
+	prefix := "test/"
+
+	output, err := generateMapstructure(input, prefix)
+	if err != nil {
+		t.Fatalf("Error :%s", err)
+	}
+	//check
+	check := map[string]interface{}{
+		"vfoo": "foo",
+		"vother": map[string]interface{}{
+			"0": map[string]interface{}{
+				"foo1": "bar",
+				"foo2": "bar",
+			},
+			"1": map[string]interface{}{
+				"bar1": "foo",
+				"bar2": "foo",
+			},
+		},
+	}
+	if !reflect.DeepEqual(check, output) {
+		t.Fatalf("Expected %#v\nGot %#v", check, output)
+	}
+}

--- a/scripts/consul-init.sh
+++ b/scripts/consul-init.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+curl -i -H "Accept: application/json" -X PUT -d "28"    http://localhost:8500/v1/kv/test/ptrstruct1/s1int
+curl -i -H "Accept: application/json" -X PUT -d "28"    http://localhost:8500/v1/kv/test/durationfield
+# curl -i -H "Accept: application/json" -X PUT -d "10"                          http://localhost:8500/v1/kv/test
+# curl -i -H "Accept: application/json" -X PUT -d "http://172.17.0.3:80"        http://localhost:8500/v1/kv/test
+# curl -i -H "Accept: application/json" -X PUT -d "1"                           http://localhost:8500/v1/kv/test

--- a/staert.go
+++ b/staert.go
@@ -118,7 +118,7 @@ func findFile(filename string, dirNfile []string) string {
 	return ""
 }
 
-// Parse calls Flaeg Load Function
+// Parse calls toml.DecodeFile() func
 func (ts *TomlSource) Parse(cmd *flaeg.Command) (*flaeg.Command, error) {
 	ts.fullpath = findFile(ts.filename, ts.dirNfullpath)
 	if len(ts.fullpath) < 2 {


### PR DESCRIPTION
It provides connection to many KV Store like `Consul`, `Etcd` or `Zookeeper` : using [libkv](https://github.com/docker/libkv) and  [mapstructure](https://github.com/mitchellh/mapstructure) packages to loas data into the struct

The whole configuration structure is stored, using architecture like this pattern :
 - Key : `<prefix1>/<prefix2>/.../<fieldNameLevel1>/<fieldNameLevel2>/.../<fieldName>`
 - Value : `<value>`
 
It handels :
 - All [mapstructure](https://github.com/mitchellh/mapstructure) features(`bool`, `int`, ... , Squashed Embeded Sub `struct`, Pointer).
 - Maps with pattern : `.../<MapFieldName>/<mapKey>` -> `<mapValue>` (Struct as key not supported)
 - Slices (and Arraies) with pattern : `.../<SliceFieldName>/<SliceIndex>` -> `<value>`