### PR TITLE
All sources can be parsed in a Sub-Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ We developed [Flæg](https://github.com/containous/flaeg) and Stært in order to
  - Stært is Command oriented
     - It use `flaeg.Command`
     - Same comportment as [Flæg](https://github.com/containous/flaeg) commands
+	- Stært supports only one Command (the Root-Command)
+	- Flæg allows you to use many Commands
+	- Only Flæg will be used if a Sub-Command is called. (because Config type could be different from one Command to another)
+	- You can add Metadata `"parseAllSources" -> "true"` to a Sub-Command if you want to parse all sources (it requires the same Config type on the Sub-Command and the Root-Command)  
 
 ## Getting Started
 ### The configuration

--- a/toml/subcmd.toml
+++ b/toml/subcmd.toml
@@ -1,0 +1,2 @@
+Vstring = "titi"
+Vint = 777


### PR DESCRIPTION
In this PR allows to parse all sources when a Sub-Command is called

- Using Metadata `"parseAllSources" -> "true"` in the Sub-Command
- It requires the same Config type on the Sub-Command and the Root-Command)


It fixes #20 