### PR TITLE
[PROPOSAL][WIP] Enable user to extract configuration from environment variables.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-    - 1.6.2
+    - 1.7.4
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We developed [Flæg](https://github.com/containous/flaeg) and Stært in order to
 	- Stært supports only one Command (the Root-Command)
 	- Flæg allows you to use many Commands
 	- Only Flæg will be used if a Sub-Command is called. (because Config type could be different from one Command to another)
-	- You can add Metadata `"parseAllSources" -> "true"` to a Sub-Command if you want to parse all sources (it requires the same Config type on the Sub-Command and the Root-Command)  
+	- You can add Metadata `"parseAllSources" -> "true"` to a Sub-Command if you want to parse all sources (it requires the same Config type on the Sub-Command and the Root-Command)
 
 ## Getting Started
 ### The configuration
@@ -56,7 +56,7 @@ type PointerSubConfiguration struct {
 }
 ```
 
-Let's initialize it: 
+Let's initialize it:
 ```go
  func main() {
 	//Init with default value
@@ -111,8 +111,8 @@ Add TOML and flæg sources
 ```go
     s.AddSource(toml)
     s.AddSource(f)
-``` 
-NB : You can change order, so that, flaeg configuration will overwrite toml one 
+```
+NB : You can change order, so that, flaeg configuration will overwrite toml one
 ### Load your configuration
 Just call LoadConfig function :
 ```go
@@ -120,9 +120,9 @@ Just call LoadConfig function :
     if err != nil {
 		//OOPS
 	}
-	//DO WHAT YOU WANT WITH loadedConfig 
+	//DO WHAT YOU WANT WITH loadedConfig
 	//OR CALL RUN FUNC
-``` 
+```
 
 ### You can call Run
 Run function will call the func `run()` from the command :
@@ -131,7 +131,7 @@ Run function will call the func `run()` from the command :
 		//OOPS
 	}
  }
-``` 
+```
  NB : If you didn't call `LoadConfig()` before, your func `run()` will use your original configuration
 ### Let's run example
 
@@ -139,7 +139,7 @@ TOML file `./toml/example.toml` :
 ```toml
 IntField= 2
 [PointerField]
-``` 
+```
 We can run the example program using folowing CLI arguments :
 ```
 $ ./example --stringfield=owerwrittenFromFlag --pointerfield.floatfield=55.55
@@ -149,7 +149,7 @@ PointerField contains:&{BoolField:true FloatField:55.55}
 
 ```
 
-## Full example : 
+## Full example :
 [Tagoæl](https://github.com/debovema/tagoael) is a trivial example which shows how Stært can be use.
 This funny golang progam takes its configuration from both TOML and Flaeg sources to display messages.
 ```shell
@@ -182,7 +182,7 @@ The package [libkv](https://github.com/docker/libkv) provides connection to many
 The whole configuration structure is stored, using architecture like this pattern :
  - Key : `<prefix1>/<prefix2>/.../<fieldNameLevel1>/<fieldNameLevel2>/.../<fieldName>`
  - Value : `<value>`
- 
+
 It handles :
  - All [mapstructure](https://github.com/mitchellh/mapstructure) features(`bool`, `int`, ... , Squashed Embedded Sub `struct`, Pointer).
  - Maps with pattern : `.../<MapFieldName>/<mapKey>` -> `<mapValue>` (Struct as key not supported)
@@ -191,7 +191,7 @@ It handles :
 Note : Hopefully, we provide the function `StoreConfig` to store your configuration structure ;)
 
 ### KvSource
-KvSource implements Source: 
+KvSource implements Source:
 
 ```go
 type KvSource struct {
@@ -200,7 +200,7 @@ type KvSource struct {
 }
 ```
 
-### Initialize 
+### Initialize
 It can be initialized like this :
 ```go
 	kv, err := staert.NewKvSource(backend store.Backend, addrs []string, options *store.Config, prefix string)

--- a/env.go
+++ b/env.go
@@ -1,0 +1,322 @@
+package staert
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/containous/flaeg"
+	"github.com/fatih/camelcase"
+)
+
+// Loader interface
+// A Loader is an object that can be used to load a configuration from a
+// configuration structure
+type Loader interface {
+	LoadConfig(config interface{}) error
+}
+
+// SourceLoader, can be both a staert.Source and a staert.Loader
+type SourceLoader interface {
+	Loader
+	Source
+}
+
+// envSource implements SourceLoader
+// Enables to populate configuration struct with informations extracted from
+// process's environment variables. Variables names are like %PREFIX%%SEP%%FIELD_NAME%
+// It supports pointer to values and struct, however not slices and arrays..
+type envSource struct {
+	prefix    string
+	separator string
+	parsers   map[reflect.Type]flaeg.Parser
+}
+
+// NewEnvSource constructs a new instance of envSource
+func NewEnvSource(prefix, separator string, parsers map[reflect.Type]flaeg.Parser) SourceLoader {
+	return &envSource{prefix, separator, parsers}
+}
+
+// Parse parse and load config structure
+func (e *envSource) Parse(cmd *flaeg.Command) (*flaeg.Command, error) {
+	return cmd, e.LoadConfig(cmd.Config)
+}
+
+func (e *envSource) LoadConfig(config interface{}) error {
+	configVal := reflect.ValueOf(config).Elem()
+
+	values, err := e.analyzeStruct(configVal.Type(), []string{})
+
+	if err != nil {
+		return err
+	}
+
+	return e.assignValues(configVal, values)
+}
+
+type envValue struct {
+	StrValue string
+	Path     path
+}
+
+type path []string
+
+func (p path) clone() []string {
+	res := make([]string, len(p))
+	copy(res, p)
+	return res
+}
+
+// Recursively scan the given config structure type information
+// and look for defined environment variables.
+func (e *envSource) analyzeStruct(configType reflect.Type, currentPath path) ([]*envValue, error) {
+	res := []*envValue{}
+
+	for i := 0; i < configType.NumField(); i++ {
+		field := configType.Field(i)
+
+		// If we're facing an embedded struct
+		if field.Anonymous {
+			values, err := e.analyzeStruct(field.Type, currentPath)
+
+			if err != nil {
+				return []*envValue{}, err
+			}
+
+			res = append(res, values...)
+			continue
+		}
+
+		values, err := e.analyzeValue(field.Type, append(currentPath, field.Name))
+
+		if err != nil {
+			return []*envValue{}, err
+		}
+
+		res = append(res, values...)
+	}
+
+	return res, nil
+}
+
+func (e *envSource) analyzeValue(valType reflect.Type, fieldPath path) ([]*envValue, error) {
+	var (
+		res []*envValue
+		err error
+	)
+	switch valType.Kind() {
+	case reflect.Array, reflect.Slice, reflect.Map:
+		res, err = e.analyzeIndexedType(valType, fieldPath)
+	case reflect.Ptr:
+		res, err = e.analyzeValue(valType.Elem(), fieldPath)
+	case reflect.Struct:
+		res, err = e.analyzeStruct(valType, fieldPath)
+	case reflect.Invalid, reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
+		err = errors.New(
+			fmt.Sprintf("type %s is not supported by EnvSource", valType.Name()),
+		)
+	default:
+		res = e.loadValue(fieldPath)
+	}
+
+	return res, err
+}
+
+func (e *envSource) analyzeIndexedType(valType reflect.Type, fieldPath path) ([]*envValue, error) {
+	var (
+		res []*envValue
+	)
+
+	prefix := e.envVarFromPath(fieldPath)
+	vars := e.envVarsWithPrefix(prefix)
+	nextKeys := unique(e.nextLevelKeys(prefix, vars))
+
+	for _, varName := range nextKeys {
+		key := e.keyFromEnvVar(varName, prefix)
+
+		// If we're on an Int based key, we need to be able to convert
+		// detected key to an int
+		if valType.Kind() == reflect.Array ||
+			valType.Kind() == reflect.Slice {
+			index, err := strconv.Atoi(key)
+
+			if err != nil {
+				return res, errors.New(
+					fmt.Sprintf(
+						key,
+						varName,
+					),
+				)
+			}
+
+			if valType.Kind() == reflect.Array &&
+				index >= valType.Len() {
+				return res, errors.New(
+					fmt.Sprintf(
+						"Detected key (%s) from variable %s is >= to array length %d",
+						key,
+						varName,
+						valType.Len(),
+					),
+				)
+			}
+		}
+
+		valPath := append(fieldPath, key)
+		keyValues, err := e.analyzeValue(valType.Elem(), valPath)
+
+		if err != nil {
+			return res, err
+		}
+
+		res = append(res, keyValues...)
+	}
+
+	return res, nil
+}
+
+func (e *envSource) loadValue(fieldPath path) []*envValue {
+	variableName := e.envVarFromPath(fieldPath)
+
+	value, ok := os.LookupEnv(variableName)
+
+	if !ok {
+		return []*envValue{}
+	}
+
+	return []*envValue{&envValue{value, fieldPath.clone()}}
+}
+
+func (e *envSource) assignValues(configVal reflect.Value, values []*envValue) error {
+	for _, v := range values {
+		currentValue := configVal
+		for _, p := range v.Path {
+			currentValue = currentValue.FieldByName(p)
+
+			if e.needsAllocation(currentValue) {
+				var err error
+				currentValue, err = e.allocate(currentValue)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if err := e.setValue(currentValue, v.StrValue); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *envSource) needsAllocation(value reflect.Value) bool {
+	// TODO
+	return false
+}
+
+func (e *envSource) allocate(value reflect.Value) (reflect.Value, error) {
+	// TODO
+	return value, nil
+}
+
+func (e *envSource) setValue(value reflect.Value, strValue string) error {
+
+	if !value.CanSet() {
+		return errors.New(
+			fmt.Sprintf(
+				"Value [%v] cannot be set",
+				value,
+			),
+		)
+	}
+
+	parser, ok := e.parsers[value.Type()]
+
+	if !ok {
+		return errors.New(
+			fmt.Sprintf(
+				"Unsupported type [%s], please consider adding custom parser",
+				value.Type().Name(),
+			),
+		)
+	}
+
+	err := parser.Set(strValue)
+
+	if err != nil {
+		return err
+	}
+
+	value.Set(reflect.ValueOf(parser).Elem().Convert(value.Type()))
+
+	return nil
+}
+
+func (e *envSource) nextLevelKeys(prefix string, envVars []string) []string {
+	res := make([]string, 0, len(envVars))
+
+	for _, envVar := range envVars {
+		nextKey := strings.Split(
+			strings.TrimPrefix(envVar, prefix+e.separator),
+			e.separator,
+		)[0]
+		res = append(res, prefix+e.separator+nextKey)
+
+	}
+
+	return res
+}
+
+func (e *envSource) envVarsWithPrefix(prefix string) []string {
+	res := []string{}
+
+	for _, rawVar := range os.Environ() {
+		varName := strings.Split(rawVar, "=")[0]
+		if strings.HasPrefix(varName, prefix) {
+			res = append(res, varName)
+		}
+	}
+
+	return res
+}
+
+func (e *envSource) keyFromEnvVar(fullVar, prefix string) string {
+	return strings.ToLower(
+		strings.Split(
+			strings.TrimPrefix(fullVar, prefix+e.separator),
+			e.separator,
+		)[0],
+	)
+}
+
+func (e *envSource) envVarFromPath(currentPath []string) string {
+	if e.prefix != "" {
+		currentPath = append([]string{e.prefix}, currentPath...)
+	}
+	s := make([]string, 0, len(currentPath))
+
+	for _, word := range currentPath {
+		s = append(s, camelcase.Split(word)...)
+	}
+
+	return strings.ToUpper(strings.Join(s, e.separator))
+}
+
+func unique(in []string) []string {
+	collector := map[string]struct{}{}
+	res := []string{}
+
+	for _, v := range in {
+		if _, ok := collector[v]; ok {
+			continue
+		}
+
+		collector[v] = struct{}{}
+		res = append(res, v)
+	}
+
+	return res
+}

--- a/env_test.go
+++ b/env_test.go
@@ -1,0 +1,759 @@
+package staert
+
+import (
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/containous/flaeg"
+)
+
+func setupEnv(env map[string]string) {
+	for k, v := range env {
+		os.Setenv(k, v)
+	}
+
+}
+func cleanupEnv(env map[string]string) {
+	for k := range env {
+		os.Unsetenv(k)
+	}
+}
+
+type basicAppConfig struct {
+	StringValue string
+	IntValue    int
+	BoolValue   bool
+}
+
+type sortableEnvValues []*envValue
+
+func (s sortableEnvValues) Len() int {
+	return len(s)
+}
+
+func (s sortableEnvValues) Less(i, j int) bool {
+	return s[i].StrValue < s[j].StrValue
+}
+
+func (s sortableEnvValues) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type testAnalyzeStructThenHook func(t *testing.T, expectation, result sortableEnvValues, err error)
+
+func testAnalyzeStructShouldSucceed(t *testing.T, expectation, result sortableEnvValues, err error) {
+	if err != nil {
+		t.Logf("Weren't expecting an error, got [%v]", err)
+		t.FailNow()
+	}
+
+	if len(expectation) != len(result) {
+		t.Logf("Unexpected count of values returned: Expected [%d] got [%d]", len(expectation), len(result))
+		t.FailNow()
+	}
+
+	// Sort by value, according to StrValue (which might not be the best
+	// idea ever), in order to ensure index based comparison consistency
+	sort.Sort(expectation)
+	sort.Sort(result)
+
+	for i, v := range expectation {
+		if v.StrValue != result[i].StrValue {
+			t.Logf("Expected [%v] got [%v]", *v, *result[i])
+			t.Fail()
+		}
+
+		if len(v.Path) != len(result[i].Path) {
+			t.Logf("Expected Path length of [%v] got [%v]", len(v.Path), len(result[i].Path))
+			t.FailNow()
+		}
+
+		for j, p := range v.Path {
+			if p != result[i].Path[j] {
+				t.Logf("Expected path term [%v] got [%v]", p, result[i].Path[j])
+				t.Fail()
+			}
+		}
+
+	}
+}
+
+func testAnalyzeStructShouldFail(t *testing.T, expectation, result sortableEnvValues, err error) {
+	if err == nil {
+		t.Logf("Expected an error, got nothing")
+		t.Fail()
+	}
+}
+
+func TestAnalyzeStruct(t *testing.T) {
+	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+
+	testCases := []struct {
+		Label       string
+		Source      interface{}
+		Expectation []*envValue
+		Env         map[string]string
+		Then        testAnalyzeStructThenHook
+	}{
+		{
+			"WithBasicConfiguration",
+			&basicAppConfig{},
+			[]*envValue{
+				&envValue{"FOOO", path{"StringValue"}},
+				&envValue{"10", path{"IntValue"}},
+				&envValue{"true", path{"BoolValue"}},
+			},
+			map[string]string{
+				"STRING_VALUE": "FOOO",
+				"INT_VALUE":    "10",
+				"BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithEmbeddedStruct",
+			&struct {
+				basicAppConfig
+				FloatValue float32
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"StringValue"}},
+				&envValue{"10", path{"IntValue"}},
+				&envValue{"true", path{"BoolValue"}},
+				&envValue{"42.1", path{"FloatValue"}},
+			},
+			map[string]string{
+				"STRING_VALUE": "FOOO",
+				"INT_VALUE":    "10",
+				"BOOL_VALUE":   "true",
+				"FLOAT_VALUE":  "42.1",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithNestedStructValue",
+			&struct {
+				Config basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "StringValue"}},
+				&envValue{"10", path{"Config", "IntValue"}},
+				&envValue{"true", path{"Config", "BoolValue"}},
+			},
+			map[string]string{
+				"CONFIG_STRING_VALUE": "FOOO",
+				"CONFIG_INT_VALUE":    "10",
+				"CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithDoubleNestedStructValue",
+			&struct {
+				Nested struct {
+					Config basicAppConfig
+				}
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Nested", "Config", "StringValue"}},
+				&envValue{"10", path{"Nested", "Config", "IntValue"}},
+				&envValue{"true", path{"Nested", "Config", "BoolValue"}},
+			},
+			map[string]string{
+				"NESTED_CONFIG_STRING_VALUE": "FOOO",
+				"NESTED_CONFIG_INT_VALUE":    "10",
+				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithNestedStructPtr",
+			&struct {
+				Config *basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "StringValue"}},
+				&envValue{"10", path{"Config", "IntValue"}},
+				&envValue{"true", path{"Config", "BoolValue"}},
+			},
+			map[string]string{
+				"CONFIG_STRING_VALUE": "FOOO",
+				"CONFIG_INT_VALUE":    "10",
+				"CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithDoubleNestedStructPtr",
+			&struct {
+				Nested *struct {
+					Config *basicAppConfig
+				}
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Nested", "Config", "StringValue"}},
+				&envValue{"10", path{"Nested", "Config", "IntValue"}},
+				&envValue{"true", path{"Nested", "Config", "BoolValue"}},
+			},
+			map[string]string{
+				"NESTED_CONFIG_STRING_VALUE": "FOOO",
+				"NESTED_CONFIG_INT_VALUE":    "10",
+				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithDoubleNestedStructMixed",
+			&struct {
+				Nested *struct {
+					Config basicAppConfig
+				}
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Nested", "Config", "StringValue"}},
+				&envValue{"10", path{"Nested", "Config", "IntValue"}},
+				&envValue{"true", path{"Nested", "Config", "BoolValue"}},
+			},
+			map[string]string{
+				"NESTED_CONFIG_STRING_VALUE": "FOOO",
+				"NESTED_CONFIG_INT_VALUE":    "10",
+				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithPtrValue",
+			&struct {
+				IntValue *int
+			}{},
+			[]*envValue{
+				&envValue{"10", path{"IntValue"}},
+			},
+			map[string]string{
+				"INT_VALUE": "10",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithNestedPtrValue",
+			&struct {
+				Config struct {
+					IntValue *int
+				}
+			}{},
+			[]*envValue{
+				&envValue{"10", path{"Config", "IntValue"}},
+			},
+			map[string]string{
+				"CONFIG_INT_VALUE": "10",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithNestedPtrValue",
+			&struct {
+				Config struct {
+					IntValue *int
+				}
+			}{},
+			[]*envValue{
+				&envValue{"10", path{"Config", "IntValue"}},
+			},
+			map[string]string{
+				"CONFIG_INT_VALUE": "10",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithPtrPtrToValue",
+			&struct {
+				Config **int
+			}{},
+			[]*envValue{
+				&envValue{"10", path{"Config"}},
+			},
+			map[string]string{
+				"CONFIG": "10",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithPtrPtrToStruct",
+			&struct {
+				Config **basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "StringValue"}},
+				&envValue{"10", path{"Config", "IntValue"}},
+				&envValue{"true", path{"Config", "BoolValue"}},
+			},
+			map[string]string{
+				"CONFIG_STRING_VALUE": "FOOO",
+				"CONFIG_INT_VALUE":    "10",
+				"CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithMapOfValues",
+			&struct {
+				Config map[string]string
+			}{},
+			[]*envValue{
+				&envValue{"FOO", path{"Config", "foo"}},
+				&envValue{"MEH", path{"Config", "bar"}},
+				&envValue{"BAR", path{"Config", "biz"}},
+			},
+			map[string]string{
+				"CONFIG_FOO": "FOO",
+				"CONFIG_BAR": "MEH",
+				"CONFIG_BIZ": "BAR",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithMapOfStructValues",
+			&struct {
+				Config map[string]basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOO", path{"Config", "foo", "StringValue"}},
+				&envValue{"MEH", path{"Config", "bar", "StringValue"}},
+				&envValue{"BAR", path{"Config", "biz", "StringValue"}},
+			},
+			map[string]string{
+				"CONFIG_FOO_STRING_VALUE": "FOO",
+				"CONFIG_BAR_STRING_VALUE": "MEH",
+				"CONFIG_BIZ_STRING_VALUE": "BAR",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithMapOfStructPtr",
+			&struct {
+				Config map[string]*basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOO", path{"Config", "foo", "StringValue"}},
+				&envValue{"MEH", path{"Config", "bar", "StringValue"}},
+				&envValue{"BAR", path{"Config", "biz", "StringValue"}},
+			},
+			map[string]string{
+				"CONFIG_FOO_STRING_VALUE": "FOO",
+				"CONFIG_BAR_STRING_VALUE": "MEH",
+				"CONFIG_BIZ_STRING_VALUE": "BAR",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithMapOfMapOfPtrStruct",
+			&struct {
+				Config map[int]map[string]*basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOO", path{"Config", "0", "foo", "StringValue"}},
+				&envValue{"MEH", path{"Config", "1", "bar", "StringValue"}},
+				&envValue{"BAR", path{"Config", "0", "biz", "StringValue"}},
+			},
+			map[string]string{
+				"CONFIG_0_FOO_STRING_VALUE": "FOO",
+				"CONFIG_1_BAR_STRING_VALUE": "MEH",
+				"CONFIG_0_BIZ_STRING_VALUE": "BAR",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithSliceToValue",
+			&struct {
+				Config []int
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0"}},
+				&envValue{"10", path{"Config", "1"}},
+				&envValue{"true", path{"Config", "2"}},
+			},
+			map[string]string{
+				"CONFIG_0": "FOOO",
+				"CONFIG_1": "10",
+				"CONFIG_2": "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithSliceToValueAndInvalidKey",
+			&struct {
+				Config []int
+			}{},
+			[]*envValue{},
+			map[string]string{
+				"CONFIG_0":      "FOOO",
+				"CONFIG_1":      "10",
+				"CONFIG_PATATE": "true",
+			},
+			testAnalyzeStructShouldFail,
+		},
+		{
+			"WithAnArrayToValue",
+			&struct {
+				Config [10]int
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0"}},
+				&envValue{"10", path{"Config", "1"}},
+				&envValue{"true", path{"Config", "2"}},
+			},
+			map[string]string{
+				"CONFIG_0": "FOOO",
+				"CONFIG_1": "10",
+				"CONFIG_2": "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithAnArrayAndAnOutOfBoundIndex",
+			&struct {
+				Config [10]int
+			}{},
+			[]*envValue{},
+			map[string]string{
+				"CONFIG_11": "10",
+			},
+			testAnalyzeStructShouldFail,
+		},
+		{
+			"WithAnArrayToValue",
+			&struct {
+				Config [10]int
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0"}},
+				&envValue{"10", path{"Config", "1"}},
+				&envValue{"true", path{"Config", "2"}},
+			},
+			map[string]string{
+				"CONFIG_0": "FOOO",
+				"CONFIG_1": "10",
+				"CONFIG_2": "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithASliceToStruct",
+			&struct {
+				Config []basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0", "StringValue"}},
+				&envValue{"10", path{"Config", "0", "IntValue"}},
+				&envValue{"MIMI", path{"Config", "1", "StringValue"}},
+				&envValue{"15", path{"Config", "1", "IntValue"}},
+			},
+			map[string]string{
+				"CONFIG_0_STRING_VALUE": "FOOO",
+				"CONFIG_0_INT_VALUE":    "10",
+				"CONFIG_1_STRING_VALUE": "MIMI",
+				"CONFIG_1_INT_VALUE":    "15",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithASliceToASliceToStruct",
+			&struct {
+				Config [][]basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0", "0", "StringValue"}},
+				&envValue{"10", path{"Config", "0", "0", "IntValue"}},
+				&envValue{"MIMI", path{"Config", "1", "1", "StringValue"}},
+				&envValue{"15", path{"Config", "1", "1", "IntValue"}},
+			},
+			map[string]string{
+				"CONFIG_0_0_STRING_VALUE": "FOOO",
+				"CONFIG_0_0_INT_VALUE":    "10",
+				"CONFIG_1_1_STRING_VALUE": "MIMI",
+				"CONFIG_1_1_INT_VALUE":    "15",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithASliceToAMapToStruct",
+			&struct {
+				Config []map[string]basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0", "foo", "StringValue"}},
+				&envValue{"10", path{"Config", "0", "foo", "IntValue"}},
+				&envValue{"MIMI", path{"Config", "1", "bar", "StringValue"}},
+				&envValue{"15", path{"Config", "1", "bar", "IntValue"}},
+			},
+			map[string]string{
+				"CONFIG_0_FOO_STRING_VALUE": "FOOO",
+				"CONFIG_0_FOO_INT_VALUE":    "10",
+				"CONFIG_1_BAR_STRING_VALUE": "MIMI",
+				"CONFIG_1_BAR_INT_VALUE":    "15",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			setupEnv(testCase.Env)
+			res, err := subject.analyzeStruct(
+				reflect.TypeOf(testCase.Source).Elem(),
+				path{},
+			)
+			testCase.Then(t, testCase.Expectation, res, err)
+			cleanupEnv(testCase.Env)
+		})
+	}
+
+}
+
+func TestEnvVarFromPath(t *testing.T) {
+	testCases := []struct {
+		Label       string
+		Prefix      string
+		Separator   string
+		Path        []string
+		Expectation string
+	}{
+		{"BlankPrefix", "", "_", []string{"Foo"}, "FOO"},
+		{"NonBlankPrefix", "YOUPI", "_", []string{"Foo"}, "YOUPI_FOO"},
+		{
+			"CamelCasedPathMembers",
+			"YOUPI",
+			"_",
+			[]string{"Foo", "IamGroot", "IAmBatman"},
+			"YOUPI_FOO_IAM_GROOT_I_AM_BATMAN",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			subject := &envSource{
+				testCase.Prefix,
+				testCase.Separator,
+				map[reflect.Type]flaeg.Parser{},
+			}
+
+			result := subject.envVarFromPath(testCase.Path)
+
+			if result != testCase.Expectation {
+				t.Logf("Expected [%s] got [%s]\n", testCase.Expectation, result)
+				t.Fail()
+			}
+		})
+	}
+
+}
+
+func TestNextLevelKeys(t *testing.T) {
+	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+	testCases := []struct {
+		Label       string
+		Prefix      string
+		EnvVars     []string
+		Expectation []string
+	}{
+		{
+			"WithPrefix",
+			"CONFIG_APP",
+			[]string{
+				"CONFIG_APP_BATMAN_FOO",
+				"CONFIG_APP_ROBIN_FOO",
+				"CONFIG_APP_JOCKER_FOO",
+			},
+			[]string{
+				"CONFIG_APP_BATMAN",
+				"CONFIG_APP_ROBIN",
+				"CONFIG_APP_JOCKER",
+			},
+		},
+		{
+			"WithDuplicates",
+			"CONFIG_APP",
+			[]string{
+				"CONFIG_APP_BATMAN_FOO",
+				"CONFIG_APP_ROBIN_FOO",
+				"CONFIG_APP_JOCKER_FOO",
+				"CONFIG_APP_BATMAN_BAR",
+			},
+			[]string{
+				"CONFIG_APP_BATMAN",
+				"CONFIG_APP_ROBIN",
+				"CONFIG_APP_JOCKER",
+				"CONFIG_APP_BATMAN",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			res := subject.nextLevelKeys(testCase.Prefix, testCase.EnvVars)
+			for i, exp := range testCase.Expectation {
+				if exp != res[i] {
+					t.Logf("Unexpected value, expected [%s] got [%s]", exp, res[i])
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func TestEnvVarsWithPrefix(t *testing.T) {
+
+	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+
+	testCases := []struct {
+		Label       string
+		Prefix      string
+		Env         map[string]string
+		Expectation []string
+	}{
+		{
+			"WithPrefix",
+			"APP",
+			map[string]string{
+				"STRING_VALUE":   "FOOO",
+				"INT_VALUE":      "10",
+				"BOOL_VALUE":     "true",
+				"APP_BOOL_VALUE": "true",
+				"APP_BAR_VALUE":  "true",
+			},
+			[]string{"APP_BOOL_VALUE", "APP_BAR_VALUE"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			setupEnv(testCase.Env)
+			res := subject.envVarsWithPrefix(testCase.Prefix)
+			for i, envVar := range testCase.Expectation {
+				if envVar != res[i] {
+					t.Logf("Invalid env variableName, expected [%s] got [%s]", envVar, res[i])
+					t.Fail()
+				}
+			}
+			cleanupEnv(testCase.Env)
+		})
+	}
+}
+
+func TestUnique(t *testing.T) {
+	testCases := []struct {
+		Label       string
+		In          []string
+		Expectation []string
+	}{
+		{
+			"WithDuplicates",
+			[]string{"FOO", "BAR", "BIZ", "FOO", "BIZ"},
+			[]string{"FOO", "BAR", "BIZ"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			res := unique(testCase.In)
+			for i, val := range testCase.Expectation {
+				if res[i] != val {
+					t.Logf("Invalid result: expected [%s] got [%s]\n", val, res[i])
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func TestKeyFromEnvVar(t *testing.T) {
+	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+	testCases := []struct {
+		Label       string
+		Prefix      string
+		EnvVar      string
+		Expectation string
+	}{
+		{"WithPrefix", "CONFIG_APP", "CONFIG_APP_BATMAN", "batman"},
+		{"WithPrefixAndSuffix", "CONFIG_APP", "CONFIG_APP_BATMAN_FOO", "batman"},
+		{"WithoutPrefix", "", "BATMAN", "batman"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			if res := subject.keyFromEnvVar(testCase.EnvVar, testCase.Prefix); res != testCase.Expectation {
+				t.Logf("Unexpected value, expected [%s] got [%s]", testCase.Expectation, res)
+				t.Fail()
+			}
+		})
+	}
+}
+
+// Dummy string parser, to enable test writing
+type testStringParser string
+
+func (s testStringParser) String() string {
+	return string(s)
+}
+
+func (s *testStringParser) Set(val string) error {
+	*s = testStringParser(val)
+	return nil
+}
+
+func (s testStringParser) SetValue(val interface{}) {}
+
+func (s testStringParser) Get() interface{} {
+	return nil
+}
+
+func TestAssignValues(t *testing.T) {
+	var stringParserValue testStringParser
+	subject := &envSource{
+		"",
+		"_",
+		map[reflect.Type]flaeg.Parser{
+			reflect.TypeOf(""): &stringParserValue,
+		},
+	}
+
+	testCases := []struct {
+		Label       string
+		Value       interface{}
+		Values      []*envValue
+		Expectation interface{}
+	}{
+		{
+			"BasicStuct",
+			&struct {
+				StringValue      string
+				OtherStringValue string
+			}{},
+			[]*envValue{
+				&envValue{"FOO", path{"StringValue"}},
+				&envValue{"BAR", path{"OtherStringValue"}},
+			},
+			&struct {
+				StringValue      string
+				OtherStringValue string
+			}{"FOO", "BAR"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			err := subject.assignValues(reflect.ValueOf(testCase.Value).Elem(), testCase.Values)
+			if err != nil {
+				t.Logf("Expected no error, got %s", err.Error())
+				t.Fail()
+			}
+
+			if !reflect.DeepEqual(testCase.Expectation, testCase.Value) {
+				t.Logf("Incorrect assignation, expected %v got %v", testCase.Expectation, testCase.Value)
+				t.Fail()
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi folks !

First of all, thanks for your amazing work around traefik :)

I was playing around with it, when I decided to setup Letsencrypt. Unfortunately I was forced to rebuild and distribute my very own image of traefik with my config file embedded in order to manage it.
I would have prefered to use environment variables to do this and simply define them using cli or in my docker-compose file.

So I decided to give a shot implementing a new source for staert which extracts configuration from environment variables.

And here comes `EnvSource` !

At the moment it visits recursively the configuraton structure and infers environment variables names according field names. It's a bit aggressive but it could be easily improved by relying on struct tags for example.

EDIT: Okay, this approach doesn't work, I'm working on something else...

Also it doesn't supports lists and maps, which is necessary in order to use it with traefik, and we don't allocate pointed values too, which is also important.

I added explaination about how to use it in the README.

This is still a WIP as I only tested it against `tagoel`, I'll integrate it with traefik tomorrow.

WDYOT ?

Cheers & thanks for your time :)