### PR TITLE
Use new method signatures from libkv fork 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,8 @@
   branch = "master"
   name = "github.com/docker/libkv"
   packages = [".","store"]
-  revision = "93ab0e6c056d325dfbb11e1d58a3b4f5f62e7f3c"
+  revision = "5e4bb288a9a74320bb03f5c18d6bdbab0d8049de"
+  source = "github.com/abronan/libkv"
 
 [[projects]]
   branch = "master"
@@ -34,6 +35,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3aadb4ce7a5f277e06175bae15447f753d97735ef990590e17e86aec05ca528b"
+  inputs-digest = "c19cc2818b19b1ea5e33bc24664cd8c6fc9f1446ae62a71a500dbb1cbef9b235"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,6 +32,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/docker/libkv"
+  source = "github.com/abronan/libkv"
 
 [[constraint]]
   branch = "master"

--- a/kv.go
+++ b/kv.go
@@ -288,7 +288,7 @@ func collateKvRecursive(objValue reflect.Value, kv map[string]string, key string
 
 // ListRecursive lists all key value children under key
 func (kv *KvSource) ListRecursive(key string, pairs map[string][]byte) error {
-	pairsN1, err := kv.List(key)
+	pairsN1, err := kv.List(key, nil)
 	if err == store.ErrKeyNotFound {
 		return nil
 	}
@@ -296,7 +296,7 @@ func (kv *KvSource) ListRecursive(key string, pairs map[string][]byte) error {
 		return err
 	}
 	if len(pairsN1) == 0 {
-		pairLeaf, err := kv.Get(key)
+		pairLeaf, err := kv.Get(key, nil)
 		if err != nil {
 			return err
 		}

--- a/kv_mock_test.go
+++ b/kv_mock_test.go
@@ -19,7 +19,7 @@ func (s *Mock) Put(key string, value []byte, opts *store.WriteOptions) error {
 	return nil
 }
 
-func (s *Mock) Get(key string) (*store.KVPair, error) {
+func (s *Mock) Get(key string, options *store.ReadOptions) (*store.KVPair, error) {
 	if s.Error {
 		return nil, errors.New("error")
 	}
@@ -36,17 +36,17 @@ func (s *Mock) Delete(key string) error {
 }
 
 // Exists mock
-func (s *Mock) Exists(key string) (bool, error) {
+func (s *Mock) Exists(key string, options *store.ReadOptions) (bool, error) {
 	return false, errors.New("exists not supported")
 }
 
 // Watch mock
-func (s *Mock) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+func (s *Mock) Watch(key string, stopCh <-chan struct{}, options *store.ReadOptions) (<-chan *store.KVPair, error) {
 	return nil, errors.New("watch not supported")
 }
 
 // WatchTree mock
-func (s *Mock) WatchTree(prefix string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+func (s *Mock) WatchTree(prefix string, stopCh <-chan struct{}, options *store.ReadOptions) (<-chan []*store.KVPair, error) {
 	return s.WatchTreeMethod(), nil
 }
 
@@ -56,7 +56,7 @@ func (s *Mock) NewLock(key string, options *store.LockOptions) (store.Locker, er
 }
 
 // List mock
-func (s *Mock) List(prefix string) ([]*store.KVPair, error) {
+func (s *Mock) List(prefix string, options *store.ReadOptions) ([]*store.KVPair, error) {
 	if s.Error {
 		return nil, errors.New("error")
 	}


### PR DESCRIPTION
In the way to migrate Træfik to the [abronan libkv fork](https://github.com/abronan/libkv) we have to migrate first stært in the way to fix dependencies.