### PR TITLE
Fix preprocessdir and findfile to be platform agnostic

### DIFF
--- a/staert.go
+++ b/staert.go
@@ -105,14 +105,8 @@ func (ts *TomlSource) ConfigFileUsed() string {
 
 func preprocessDir(dirIn string) (string, error) {
 	dirOut := dirIn
-	if strings.HasPrefix(dirIn, "$") {
-		end := strings.Index(dirIn, string(os.PathSeparator))
-		if end == -1 {
-			end = len(dirIn)
-		}
-		dirOut = os.Getenv(dirIn[1:end]) + dirIn[end:]
-	}
-	dirOut, err := filepath.Abs(dirOut)
+	expanded := os.ExpandEnv(dirIn)
+	dirOut, err := filepath.Abs(expanded)
 	return dirOut, err
 }
 

--- a/staert.go
+++ b/staert.go
@@ -117,7 +117,8 @@ func findFile(filename string, dirNfile []string) string {
 			if fileInfo, err := os.Stat(fullPath); err == nil && !fileInfo.IsDir() {
 				return fullPath
 			}
-			fullPath = fullPath + "/" + filename + ".toml"
+
+			fullPath = filepath.Join(fullPath, filename+".toml")
 			if fileInfo, err := os.Stat(fullPath); err == nil && !fileInfo.IsDir() {
 				return fullPath
 			}

--- a/staert_test.go
+++ b/staert_test.go
@@ -1559,7 +1559,7 @@ func TestFindFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error: %v", err)
 	}
-	expected := thisPath + "/toml/nothing.toml"
+	expected := filepath.Join(thisPath, "toml", "nothing.toml")
 	if result != expected {
 		t.Errorf("Expected %s\ngot %s", expected, result)
 	}
@@ -1612,7 +1612,7 @@ func TestFindFileSliceFileAndDirLastIf(t *testing.T) {
 
 	//check
 	thisPath, _ := filepath.Abs(".")
-	check := thisPath + "/toml/trivial.toml"
+	check := filepath.Join(thisPath, "/toml/trivial.toml")
 	if result := findFile("trivial", []string{"./toml/", "/any/other/path"}); result != check {
 		t.Errorf("Expected %s\nGot %s", check, result)
 	}
@@ -1622,7 +1622,7 @@ func TestFindFileSliceFileAndDirFirstIf(t *testing.T) {
 	inDirNfile := []string{"$PWD/toml/nothing.toml"}
 	//check
 	thisPath, _ := filepath.Abs(".")
-	check := thisPath + "/toml/nothing.toml"
+	check := filepath.Join(thisPath, "/toml/nothing.toml")
 	if result := findFile(inFilename, inDirNfile); result != check {
 		t.Errorf("Expected %s\nGot %s", check, result)
 	}

--- a/staert_test.go
+++ b/staert_test.go
@@ -1519,9 +1519,7 @@ func TestPreprocessDir(t *testing.T) {
 	}
 	checkMap := map[string]string{
 		".":                   thisPath,
-		"$HOME":               os.Getenv("HOME"),
 		"dir1/dir2":           thisPath + "/dir1/dir2",
-		"$HOME/dir1/dir2":     os.Getenv("HOME") + "/dir1/dir2",
 		"/etc/test":           "/etc/test",
 		"/etc/dir1/file1.ext": "/etc/dir1/file1.ext",
 	}
@@ -1530,11 +1528,27 @@ func TestPreprocessDir(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error: %v", err)
 		}
-		if check != out {
-			t.Errorf("input %s\nexpected %s\n got %s", in, check, out)
+
+		//always check against the absolute path
+		checkAbs, _ := filepath.Abs(check)
+
+		if checkAbs != out {
+			t.Errorf("input %s\nexpected %s\n got %s", in, checkAbs, out)
 		}
 	}
 
+}
+func TestPreprocessDirEnvVariablesExpansions(t *testing.T) {
+	expected, _ := filepath.Abs("/some/path/my/path")
+	in := "$TEST_ENV_VARIABLE/my/path"
+	os.Setenv("TEST_ENV_VARIABLE", "/some/path")
+	out, err := preprocessDir(in)
+	if err != nil {
+		t.Errorf("Error: %v", err)
+	}
+	if out != expected {
+		t.Errorf("input %s\nexpected %s\n got %s", in, expected, out)
+	}
 }
 
 func TestFindFile(t *testing.T) {


### PR DESCRIPTION
Fixing some tests and using `filepath` and `os` packages to handle paths instead of handrolled string concatenations.
  
Fixes #36