### PR TITLE
Migrate from libkv to valkeyrie library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,16 +9,15 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/containous/flaeg"
-  packages = ["."]
-  revision = "4b6f66624dce34a226f080b414c4705ea8731bc5"
+  name = "github.com/abronan/valkeyrie"
+  packages = [".","store"]
+  revision = "063d875e3c5fd734fa2aa12fac83829f62acfc70"
 
 [[projects]]
   branch = "master"
-  name = "github.com/docker/libkv"
-  packages = [".","store"]
-  revision = "5e4bb288a9a74320bb03f5c18d6bdbab0d8049de"
-  source = "github.com/abronan/libkv"
+  name = "github.com/containous/flaeg"
+  packages = ["."]
+  revision = "4b6f66624dce34a226f080b414c4705ea8731bc5"
 
 [[projects]]
   branch = "master"
@@ -35,6 +34,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c19cc2818b19b1ea5e33bc24664cd8c6fc9f1446ae62a71a500dbb1cbef9b235"
+  inputs-digest = "431d98d658e2cb8b7cced3138a278a8632f666f123bc250532ae661babb055c0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,9 +31,8 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/docker/libkv"
-  source = "github.com/abronan/libkv"
+  name = "github.com/mitchellh/mapstructure"
 
 [[constraint]]
   branch = "master"
-  name = "github.com/mitchellh/mapstructure"
+  name = "github.com/abronan/valkeyrie"

--- a/kv.go
+++ b/kv.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/abronan/valkeyrie"
+	"github.com/abronan/valkeyrie/store"
 	"github.com/containous/flaeg"
-	"github.com/docker/libkv"
-	"github.com/docker/libkv/store"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -27,11 +27,11 @@ type KvSource struct {
 
 // NewKvSource creates a new KvSource
 func NewKvSource(backend store.Backend, addrs []string, options *store.Config, prefix string) (*KvSource, error) {
-	kvStore, err := libkv.NewStore(backend, addrs, options)
+	kvStore, err := valkeyrie.NewStore(backend, addrs, options)
 	return &KvSource{Store: kvStore, Prefix: prefix}, err
 }
 
-// Parse uses libkv and mapstructure to fill the structure
+// Parse uses valkeyrie and mapstructure to fill the structure
 func (kv *KvSource) Parse(cmd *flaeg.Command) (*flaeg.Command, error) {
 	err := kv.LoadConfig(cmd.Config)
 	if err != nil {

--- a/kv_mock_test.go
+++ b/kv_mock_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/docker/libkv/store"
+	"github.com/abronan/valkeyrie/store"
 )
 
 // Extremely limited mock store so we can test initialization

--- a/kv_test.go
+++ b/kv_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/abronan/valkeyrie/store"
 	"github.com/containous/flaeg"
-	"github.com/docker/libkv/store"
 	"github.com/mitchellh/mapstructure"
 )
 


### PR DESCRIPTION
Migrate from the `labronan/libkv` library to its new repository `abronan/valkeyrie`.