### PR TITLE
Replace Base64 encoding by Gzip compression

### DIFF
--- a/kv_test.go
+++ b/kv_test.go
@@ -1,7 +1,10 @@
 package staert
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
+	"io/ioutil"
 	"reflect"
 	"strings"
 	"testing"
@@ -1094,11 +1097,13 @@ func TestConvertPairs5Levels(t *testing.T) {
 	}
 }
 
-func TestCollateKvPairsBase64(t *testing.T) {
+func TestCollateKvPairsCompressedData(t *testing.T) {
+
+	strToCompress := "Testing automatic compressed data if byte array"
 	config := &struct {
-		Base64Bytes []byte
+		CompressedDataBytes []byte
 	}{
-		Base64Bytes: []byte("Testing automatic base64 if byte array"),
+		CompressedDataBytes: []byte(strToCompress),
 	}
 
 	//test
@@ -1107,21 +1112,31 @@ func TestCollateKvPairsBase64(t *testing.T) {
 		t.Fatalf("Error: %v", err)
 	}
 
-	expected := map[string]string{
-		"prefix/base64bytes": "VGVzdGluZyBhdXRvbWF0aWMgYmFzZTY0IGlmIGJ5dGUgYXJyYXk=",
+	compressedVal := kv["prefix/compresseddatabytes"]
+	if len(compressedVal) == 0 {
+		t.Fatal("Error : no entry for 'prefix/compresseddatabytes'.")
 	}
-	if !reflect.DeepEqual(kv, expected) {
-		t.Fatalf("Got: %s\nExpected: %s", kv, expected)
+	b := bytes.NewBuffer([]byte(compressedVal))
+	r, err := gzip.NewReader(b)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	defer r.Close()
+	s, err := ioutil.ReadAll(r)
+	data := string(s)
+
+	if strToCompress != data {
+		t.Fatalf("Got: %s\nExpected: %s", kv, strToCompress)
 	}
 }
 
-type TestBase64Struct struct {
-	Base64Bytes []byte
+type TestCompressedDataStruct struct {
+	CompressedDataBytes []byte
 }
 
-func TestParseKvSourceBase64(t *testing.T) {
+func TestParseKvSourceCompressedData(t *testing.T) {
 	//Init
-	config := TestBase64Struct{}
+	config := TestCompressedDataStruct{}
 
 	//Test
 	rootCmd := &flaeg.Command{
@@ -1131,36 +1146,59 @@ func TestParseKvSourceBase64(t *testing.T) {
 		DefaultPointersConfig: &config,
 		Run: func() error { return nil },
 	}
-	kv := &KvSource{
-		&Mock{
-			KVPairs: []*store.KVPair{
-				{
-					Key:   "test/base64bytes",
-					Value: []byte("VGVzdGluZyBhdXRvbWF0aWMgYmFzZTY0IGlmIGJ5dGUgYXJyYXk="),
+
+	strToCompress := "Testing automatic compressed data if byte array"
+	var b bytes.Buffer
+	w := gzip.NewWriter(&b)
+	w.Write([]byte(strToCompress))
+	w.Close()
+
+	kvs := []*KvSource{
+		&KvSource{
+			&Mock{
+				KVPairs: []*store.KVPair{
+					{
+						Key:   "test/compresseddatabytes",
+						Value: b.Bytes(),
+					},
 				},
 			},
+			"test",
 		},
-		"test",
-	}
-	if _, err := kv.Parse(rootCmd); err != nil {
-		t.Fatalf("Error %s", err)
+		&KvSource{
+			&Mock{
+				KVPairs: []*store.KVPair{
+					{
+						Key:   "test/compresseddatabytes",
+						Value: []byte("VGVzdGluZyBhdXRvbWF0aWMgY29tcHJlc3NlZCBkYXRhIGlmIGJ5dGUgYXJyYXk="),
+					},
+				},
+			},
+			"test",
+		},
 	}
 
-	//Check
-	expected := &TestBase64Struct{
-		Base64Bytes: []byte("Testing automatic base64 if byte array"),
-	}
+	for _, kv := range kvs {
+		if _, err := kv.Parse(rootCmd); err != nil {
+			t.Fatalf("Error %s", err)
+		}
 
-	if !reflect.DeepEqual(expected, rootCmd.Config) {
-		actualJSON, err := json.Marshal(rootCmd.Config)
-		if err != nil {
-			t.Fatalf("Error: %v", err)
+		//Check
+		expected := &TestCompressedDataStruct{
+			CompressedDataBytes: []byte(strToCompress),
 		}
-		expectedJSON, err := json.Marshal(expected)
-		if err != nil {
-			t.Fatalf("Error: %v", err)
+
+		if !reflect.DeepEqual(expected, rootCmd.Config) {
+			actualJSON, err := json.Marshal(rootCmd.Config)
+			if err != nil {
+				t.Fatalf("Error: %v", err)
+			}
+			expectedJSON, err := json.Marshal(expected)
+			if err != nil {
+				t.Fatalf("Error: %v", err)
+			}
+			t.Fatalf("\nexpected\t: %s\ngot\t\t\t: %s\n", expectedJSON, actualJSON)
 		}
-		t.Fatalf("\nexpected\t: %s\ngot\t\t\t: %s\n", expectedJSON, actualJSON)
 	}
 }
 

--- a/kv_test.go
+++ b/kv_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
-	"io/ioutil"
 	"reflect"
 	"strings"
 	"testing"
@@ -1116,17 +1115,15 @@ func TestCollateKvPairsCompressedData(t *testing.T) {
 	if len(compressedVal) == 0 {
 		t.Fatal("Error : no entry for 'prefix/compresseddatabytes'.")
 	}
-	b := bytes.NewBuffer([]byte(compressedVal))
-	r, err := gzip.NewReader(b)
+
+	data, err := gzipReader(compressedVal)
+	dataStr := string(data.([]byte))
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
-	defer r.Close()
-	s, err := ioutil.ReadAll(r)
-	data := string(s)
 
-	if strToCompress != data {
-		t.Fatalf("Got: %s\nExpected: %s", kv, strToCompress)
+	if strToCompress != dataStr {
+		t.Fatalf("Got: %q\nExpected: %q", dataStr, strToCompress)
 	}
 }
 

--- a/kv_test.go
+++ b/kv_test.go
@@ -1116,8 +1116,8 @@ func TestCollateKvPairsCompressedData(t *testing.T) {
 		t.Fatal("Error : no entry for 'prefix/compresseddatabytes'.")
 	}
 
-	data, err := gzipReader(compressedVal)
-	dataStr := string(data.([]byte))
+	data, err := readCompressedData(compressedVal, gzipReader)
+	dataStr := string(data)
 	if err != nil {
 		t.Fatalf("Error: %v", err)
 	}
@@ -1145,6 +1145,7 @@ func TestParseKvSourceCompressedData(t *testing.T) {
 	}
 
 	strToCompress := "Testing automatic compressed data if byte array"
+
 	var b bytes.Buffer
 	w := gzip.NewWriter(&b)
 	w.Write([]byte(strToCompress))


### PR DESCRIPTION
Today, byte array are Base64 encoded before to be stored in a KV store.
But the size of these data can be a problem.

Indeed, KV stores, like Consul, can only store values with a size up to 500 KB.

This PR allows replacing Base64 encoded data by gzip compressed data to reduce the size of these data.

**Note :** If data cannot be unzipped, they are _Base64  decoded_ to preserve the backward compatibility.

Unit tests have been updated too.

Related to https://github.com/containous/traefik/issues/1325