### PR TITLE
Handle edge cases

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,15 +9,15 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/containous/flaeg"
-  packages = [".","parse"]
-  revision = "c4797734e8b31bd78dc2cc5d88d510decdee2d7e"
+  name = "github.com/abronan/valkeyrie"
+  packages = [".","store"]
+  revision = "063d875e3c5fd734fa2aa12fac83829f62acfc70"
 
 [[projects]]
   branch = "master"
   name = "github.com/containous/flaeg"
-  packages = ["."]
-  revision = "4b6f66624dce34a226f080b414c4705ea8731bc5"
+  packages = [".","parse"]
+  revision = "c4797734e8b31bd78dc2cc5d88d510decdee2d7e"
 
 [[projects]]
   branch = "master"
@@ -40,6 +40,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b9988ecf666c436d27f0430830df8cecf007e94926e566238aaeb410deab01fa"
+  inputs-digest = "ffc28556ec3ec497812696810606e7f0ba6ec6d08b62470dafa16151f099c7c9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,15 +9,21 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/abronan/valkeyrie"
-  packages = [".","store"]
-  revision = "063d875e3c5fd734fa2aa12fac83829f62acfc70"
+  name = "github.com/containous/flaeg"
+  packages = [".","parse"]
+  revision = "c4797734e8b31bd78dc2cc5d88d510decdee2d7e"
 
 [[projects]]
   branch = "master"
   name = "github.com/containous/flaeg"
   packages = ["."]
   revision = "4b6f66624dce34a226f080b414c4705ea8731bc5"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/fatih/camelcase"
+  packages = ["."]
+  revision = "44e46d280b43ec1531bb25252440e34f1b800b65"
 
 [[projects]]
   branch = "master"
@@ -34,6 +40,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "431d98d658e2cb8b7cced3138a278a8632f666f123bc250532ae661babb055c0"
+  inputs-digest = "b9988ecf666c436d27f0430830df8cecf007e94926e566238aaeb410deab01fa"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,8 +26,8 @@
   name = "github.com/BurntSushi/toml"
 
 [[constraint]]
+  branch = "master"
   name = "github.com/containous/flaeg"
-  version = "v1.0.0"
 
 [[constraint]]
   branch = "master"

--- a/envsource.go
+++ b/envsource.go
@@ -1,0 +1,323 @@
+package staert
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/containous/flaeg"
+	"github.com/containous/flaeg/parse"
+	"github.com/fatih/camelcase"
+)
+
+// Loader interface
+// A Loader is an object that can be used to load a configuration from a
+// configuration structure
+type Loader interface {
+	LoadConfig(config interface{}) error
+}
+
+// SourceLoader, can be both a staert.Source and a staert.Loader
+type SourceLoader interface {
+	Loader
+	Source
+}
+
+// envSource implements SourceLoader
+// Enables to populate configuration struct with informations extracted from
+// process's environment variables. Variables names are like %PREFIX%%SEP%%FIELD_NAME%
+// It supports pointer to values and struct, however not slices and arrays..
+type envSource struct {
+	prefix    string
+	separator string
+	parsers   map[reflect.Type]parse.Parser
+}
+
+// NewEnvSource constructs a new instance of envSource
+func NewEnvSource(prefix, separator string, parsers map[reflect.Type]parse.Parser) SourceLoader {
+	return &envSource{prefix, separator, parsers}
+}
+
+// Parse parse and load config structure
+func (e *envSource) Parse(cmd *flaeg.Command) (*flaeg.Command, error) {
+	return cmd, e.LoadConfig(cmd.Config)
+}
+
+func (e *envSource) LoadConfig(config interface{}) error {
+	configVal := reflect.ValueOf(config).Elem()
+
+	values, err := e.analyzeStruct(configVal.Type(), []string{})
+
+	if err != nil {
+		return err
+	}
+
+	return e.assignValues(configVal, values)
+}
+
+type envValue struct {
+	StrValue string
+	Path     path
+}
+
+type path []string
+
+func (p path) clone() []string {
+	res := make([]string, len(p))
+	copy(res, p)
+	return res
+}
+
+// Recursively scan the given config structure type information
+// and look for defined environment variables.
+func (e *envSource) analyzeStruct(configType reflect.Type, currentPath path) ([]*envValue, error) {
+	res := []*envValue{}
+
+	for i := 0; i < configType.NumField(); i++ {
+		field := configType.Field(i)
+
+		// If we're facing an embedded struct
+		if field.Anonymous {
+			values, err := e.analyzeStruct(field.Type, currentPath)
+
+			if err != nil {
+				return []*envValue{}, err
+			}
+
+			res = append(res, values...)
+			continue
+		}
+
+		values, err := e.analyzeValue(field.Type, append(currentPath, field.Name))
+
+		if err != nil {
+			return []*envValue{}, err
+		}
+
+		res = append(res, values...)
+	}
+
+	return res, nil
+}
+
+func (e *envSource) analyzeValue(valType reflect.Type, fieldPath path) ([]*envValue, error) {
+	var (
+		res []*envValue
+		err error
+	)
+	switch valType.Kind() {
+	case reflect.Array, reflect.Slice, reflect.Map:
+		res, err = e.analyzeIndexedType(valType, fieldPath)
+	case reflect.Ptr:
+		res, err = e.analyzeValue(valType.Elem(), fieldPath)
+	case reflect.Struct:
+		res, err = e.analyzeStruct(valType, fieldPath)
+	case reflect.Invalid, reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
+		err = errors.New(
+			fmt.Sprintf("type %s is not supported by EnvSource", valType.Name()),
+		)
+	default:
+		res = e.loadValue(fieldPath)
+	}
+
+	return res, err
+}
+
+func (e *envSource) analyzeIndexedType(valType reflect.Type, fieldPath path) ([]*envValue, error) {
+	var (
+		res []*envValue
+	)
+
+	prefix := e.envVarFromPath(fieldPath)
+	vars := e.envVarsWithPrefix(prefix)
+	nextKeys := unique(e.nextLevelKeys(prefix, vars))
+
+	for _, varName := range nextKeys {
+		key := e.keyFromEnvVar(varName, prefix)
+
+		// If we're on an Int based key, we need to be able to convert
+		// detected key to an int
+		if valType.Kind() == reflect.Array ||
+			valType.Kind() == reflect.Slice {
+			index, err := strconv.Atoi(key)
+
+			if err != nil {
+				return res, errors.New(
+					fmt.Sprintf(
+						key,
+						varName,
+					),
+				)
+			}
+
+			if valType.Kind() == reflect.Array &&
+				index >= valType.Len() {
+				return res, errors.New(
+					fmt.Sprintf(
+						"Detected key (%s) from variable %s is >= to array length %d",
+						key,
+						varName,
+						valType.Len(),
+					),
+				)
+			}
+		}
+
+		valPath := append(fieldPath, key)
+		keyValues, err := e.analyzeValue(valType.Elem(), valPath)
+
+		if err != nil {
+			return res, err
+		}
+
+		res = append(res, keyValues...)
+	}
+
+	return res, nil
+}
+
+func (e *envSource) loadValue(fieldPath path) []*envValue {
+	variableName := e.envVarFromPath(fieldPath)
+
+	value, ok := os.LookupEnv(variableName)
+
+	if !ok {
+		return []*envValue{}
+	}
+
+	return []*envValue{&envValue{value, fieldPath.clone()}}
+}
+
+func (e *envSource) assignValues(configVal reflect.Value, values []*envValue) error {
+	for _, v := range values {
+		currentValue := configVal
+		for _, p := range v.Path {
+			currentValue = currentValue.FieldByName(p)
+
+			if e.needsAllocation(currentValue) {
+				var err error
+				currentValue, err = e.allocate(currentValue)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		if err := e.setValue(currentValue, v.StrValue); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *envSource) needsAllocation(value reflect.Value) bool {
+	// TODO
+	return false
+}
+
+func (e *envSource) allocate(value reflect.Value) (reflect.Value, error) {
+	// TODO
+	return value, nil
+}
+
+func (e *envSource) setValue(value reflect.Value, strValue string) error {
+
+	if !value.CanSet() {
+		return errors.New(
+			fmt.Sprintf(
+				"Value [%v] cannot be set",
+				value,
+			),
+		)
+	}
+
+	parser, ok := e.parsers[value.Type()]
+
+	if !ok {
+		return errors.New(
+			fmt.Sprintf(
+				"Unsupported type [%s], please consider adding custom parser",
+				value.Type().Name(),
+			),
+		)
+	}
+
+	err := parser.Set(strValue)
+
+	if err != nil {
+		return err
+	}
+
+	value.Set(reflect.ValueOf(parser).Elem().Convert(value.Type()))
+
+	return nil
+}
+
+func (e *envSource) nextLevelKeys(prefix string, envVars []string) []string {
+	res := make([]string, 0, len(envVars))
+
+	for _, envVar := range envVars {
+		nextKey := strings.Split(
+			strings.TrimPrefix(envVar, prefix+e.separator),
+			e.separator,
+		)[0]
+		res = append(res, prefix+e.separator+nextKey)
+
+	}
+
+	return res
+}
+
+func (e *envSource) envVarsWithPrefix(prefix string) []string {
+	res := []string{}
+
+	for _, rawVar := range os.Environ() {
+		varName := strings.Split(rawVar, "=")[0]
+		if strings.HasPrefix(varName, prefix) {
+			res = append(res, varName)
+		}
+	}
+
+	return res
+}
+
+func (e *envSource) keyFromEnvVar(fullVar, prefix string) string {
+	return strings.ToLower(
+		strings.Split(
+			strings.TrimPrefix(fullVar, prefix+e.separator),
+			e.separator,
+		)[0],
+	)
+}
+
+func (e *envSource) envVarFromPath(currentPath []string) string {
+	if e.prefix != "" {
+		currentPath = append([]string{e.prefix}, currentPath...)
+	}
+	s := make([]string, 0, len(currentPath))
+
+	for _, word := range currentPath {
+		s = append(s, camelcase.Split(word)...)
+	}
+
+	return strings.ToUpper(strings.Join(s, e.separator))
+}
+
+func unique(in []string) []string {
+	collector := map[string]struct{}{}
+	res := []string{}
+
+	for _, v := range in {
+		if _, ok := collector[v]; ok {
+			continue
+		}
+
+		collector[v] = struct{}{}
+		res = append(res, v)
+	}
+
+	return res
+}

--- a/envsource.go
+++ b/envsource.go
@@ -78,6 +78,11 @@ func (e *envSource) analyzeStruct(configType reflect.Type, currentPath path) ([]
 	for i := 0; i < configType.NumField(); i++ {
 		field := configType.Field(i)
 
+		//TODO: Handle this case;
+		//find the find the underlying struct and process it.
+		if field.Type.Kind() == reflect.Interface {
+			continue //skip fields of kind interface
+		}
 		// If we're facing an embedded struct
 		if field.Anonymous {
 			values, err := e.analyzeStruct(field.Type, currentPath)

--- a/envsource.go
+++ b/envsource.go
@@ -1,7 +1,6 @@
 package staert
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -20,7 +19,7 @@ type Loader interface {
 	LoadConfig(config interface{}) error
 }
 
-// SourceLoader, can be both a staert.Source and a staert.Loader
+// SourceLoader : can be both a staert.Source and a staert.Loader
 type SourceLoader interface {
 	Loader
 	Source
@@ -116,9 +115,8 @@ func (e *envSource) analyzeValue(valType reflect.Type, fieldPath path) ([]*envVa
 	case reflect.Struct:
 		res, err = e.analyzeStruct(valType, fieldPath)
 	case reflect.Invalid, reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
-		err = errors.New(
-			fmt.Sprintf("type %s is not supported by EnvSource", valType.Name()),
-		)
+		err = fmt.Errorf("type %s is not supported by EnvSource", valType.Name())
+
 	default:
 		res = e.loadValue(fieldPath)
 	}
@@ -145,23 +143,19 @@ func (e *envSource) analyzeIndexedType(valType reflect.Type, fieldPath path) ([]
 			index, err := strconv.Atoi(key)
 
 			if err != nil {
-				return res, errors.New(
-					fmt.Sprintf(
-						key,
-						varName,
-					),
+				return res, fmt.Errorf(
+					key,
+					varName,
 				)
 			}
 
 			if valType.Kind() == reflect.Array &&
 				index >= valType.Len() {
-				return res, errors.New(
-					fmt.Sprintf(
-						"Detected key (%s) from variable %s is >= to array length %d",
-						key,
-						varName,
-						valType.Len(),
-					),
+				return res, fmt.Errorf(
+					"Detected key (%s) from variable %s is >= to array length %d",
+					key,
+					varName,
+					valType.Len(),
 				)
 			}
 		}
@@ -226,22 +220,18 @@ func (e *envSource) allocate(value reflect.Value) (reflect.Value, error) {
 func (e *envSource) setValue(value reflect.Value, strValue string) error {
 
 	if !value.CanSet() {
-		return errors.New(
-			fmt.Sprintf(
-				"Value [%v] cannot be set",
-				value,
-			),
+		return fmt.Errorf(
+			"Value [%v] cannot be set",
+			value,
 		)
 	}
 
 	parser, ok := e.parsers[value.Type()]
 
 	if !ok {
-		return errors.New(
-			fmt.Sprintf(
-				"Unsupported type [%s], please consider adding custom parser",
-				value.Type().Name(),
-			),
+		return fmt.Errorf(
+			"Unsupported type [%s], please consider adding custom parser",
+			value.Type().Name(),
 		)
 	}
 

--- a/envsource.go
+++ b/envsource.go
@@ -95,6 +95,13 @@ func (e *envSource) analyzeStruct(configType reflect.Type, currentPath path) ([]
 			continue
 		}
 
+		// unexported fields must be handled after embdedded structs (field.Anonymous)
+		// because the PkgPath is also null for them.
+		// ref: https://github.com/golang/go/issues/21122
+		if field.PkgPath != "" { //field is unexported
+			continue
+		}
+
 		values, err := e.analyzeValue(field.Type, append(currentPath, field.Name))
 
 		if err != nil {

--- a/envsource_test.go
+++ b/envsource_test.go
@@ -615,15 +615,15 @@ func TestEnvVarsWithPrefix(t *testing.T) {
 	}{
 		{
 			"WithPrefix",
-			"APP",
+			"STAERT_APP",
 			map[string]string{
-				"STRING_VALUE":   "FOOO",
-				"INT_VALUE":      "10",
-				"BOOL_VALUE":     "true",
-				"APP_BOOL_VALUE": "true",
-				"APP_BAR_VALUE":  "true",
+				"STRING_VALUE":          "FOOO",
+				"INT_VALUE":             "10",
+				"BOOL_VALUE":            "true",
+				"STAERT_APP_BOOL_VALUE": "true",
+				"STAERT_APP_BAR_VALUE":  "true",
 			},
-			[]string{"APP_BOOL_VALUE", "APP_BAR_VALUE"},
+			[]string{"STAERT_APP_BAR_VALUE", "STAERT_APP_BOOL_VALUE"},
 		},
 	}
 
@@ -631,8 +631,9 @@ func TestEnvVarsWithPrefix(t *testing.T) {
 		t.Run(testCase.Label, func(t *testing.T) {
 			setupEnv(testCase.Env)
 			res := subject.envVarsWithPrefix(testCase.Prefix)
+			sort.Strings(res)
 			for i, envVar := range testCase.Expectation {
-				if envVar != res[i] {
+				if res != nil && envVar != res[i] {
 					t.Logf("Invalid env variableName, expected [%s] got [%s]", envVar, res[i])
 					t.Fail()
 				}

--- a/envsource_test.go
+++ b/envsource_test.go
@@ -123,6 +123,21 @@ func TestAnalyzeStruct(t *testing.T) {
 			testAnalyzeStructShouldSucceed,
 		},
 		{
+			"WithUnexportedFields",
+			&struct {
+				unexported string
+				IntValue   int
+			}{},
+			[]*envValue{
+				&envValue{"10", path{"IntValue"}},
+			},
+			map[string]string{
+				"UNEXPORTED": "FOOO",
+				"INT_VALUE":  "10",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
 			"WithEmbeddedStruct",
 			&struct {
 				basicAppConfig

--- a/envsource_test.go
+++ b/envsource_test.go
@@ -27,6 +27,16 @@ type basicAppConfig struct {
 	BoolValue   bool
 }
 
+type typeInterface interface {
+	Foo() string
+}
+
+type delegatorType struct {
+	typeInterface
+	IntValue    int
+	StringValue string
+}
+
 type sortableEnvValues []*envValue
 
 func (s sortableEnvValues) Len() int {
@@ -293,6 +303,19 @@ func TestAnalyzeStruct(t *testing.T) {
 				"CONFIG_STRING_VALUE": "FOOO",
 				"CONFIG_INT_VALUE":    "10",
 				"CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithInterfaceDelegation",
+			&delegatorType{},
+			[]*envValue{
+				&envValue{"FOOO", path{"StringValue"}},
+				&envValue{"10", path{"IntValue"}},
+			},
+			map[string]string{
+				"STRING_VALUE": "FOOO",
+				"INT_VALUE":    "10",
 			},
 			testAnalyzeStructShouldSucceed,
 		},

--- a/envsource_test.go
+++ b/envsource_test.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/containous/flaeg"
+	"github.com/containous/flaeg/parse"
 )
 
 func setupEnv(env map[string]string) {
@@ -88,7 +88,7 @@ func testAnalyzeStructShouldFail(t *testing.T, expectation, result sortableEnvVa
 }
 
 func TestAnalyzeStruct(t *testing.T) {
-	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+	subject := &envSource{"", "_", map[reflect.Type]parse.Parser{}}
 
 	testCases := []struct {
 		Label       string
@@ -536,7 +536,7 @@ func TestEnvVarFromPath(t *testing.T) {
 			subject := &envSource{
 				testCase.Prefix,
 				testCase.Separator,
-				map[reflect.Type]flaeg.Parser{},
+				map[reflect.Type]parse.Parser{},
 			}
 
 			result := subject.envVarFromPath(testCase.Path)
@@ -551,7 +551,7 @@ func TestEnvVarFromPath(t *testing.T) {
 }
 
 func TestNextLevelKeys(t *testing.T) {
-	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+	subject := &envSource{"", "_", map[reflect.Type]parse.Parser{}}
 	testCases := []struct {
 		Label       string
 		Prefix      string
@@ -605,7 +605,7 @@ func TestNextLevelKeys(t *testing.T) {
 
 func TestEnvVarsWithPrefix(t *testing.T) {
 
-	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+	subject := &envSource{"", "_", map[reflect.Type]parse.Parser{}}
 
 	testCases := []struct {
 		Label       string
@@ -669,7 +669,7 @@ func TestUnique(t *testing.T) {
 }
 
 func TestKeyFromEnvVar(t *testing.T) {
-	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+	subject := &envSource{"", "_", map[reflect.Type]parse.Parser{}}
 	testCases := []struct {
 		Label       string
 		Prefix      string
@@ -714,7 +714,7 @@ func TestAssignValues(t *testing.T) {
 	subject := &envSource{
 		"",
 		"_",
-		map[reflect.Type]flaeg.Parser{
+		map[reflect.Type]parse.Parser{
 			reflect.TypeOf(""): &stringParserValue,
 		},
 	}

--- a/envsource_test.go
+++ b/envsource_test.go
@@ -1,0 +1,759 @@
+package staert
+
+import (
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/containous/flaeg"
+)
+
+func setupEnv(env map[string]string) {
+	for k, v := range env {
+		os.Setenv(k, v)
+	}
+
+}
+func cleanupEnv(env map[string]string) {
+	for k := range env {
+		os.Unsetenv(k)
+	}
+}
+
+type basicAppConfig struct {
+	StringValue string
+	IntValue    int
+	BoolValue   bool
+}
+
+type sortableEnvValues []*envValue
+
+func (s sortableEnvValues) Len() int {
+	return len(s)
+}
+
+func (s sortableEnvValues) Less(i, j int) bool {
+	return s[i].StrValue < s[j].StrValue
+}
+
+func (s sortableEnvValues) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+type testAnalyzeStructThenHook func(t *testing.T, expectation, result sortableEnvValues, err error)
+
+func testAnalyzeStructShouldSucceed(t *testing.T, expectation, result sortableEnvValues, err error) {
+	if err != nil {
+		t.Logf("Weren't expecting an error, got [%v]", err)
+		t.FailNow()
+	}
+
+	if len(expectation) != len(result) {
+		t.Logf("Unexpected count of values returned: Expected [%d] got [%d]", len(expectation), len(result))
+		t.FailNow()
+	}
+
+	// Sort by value, according to StrValue (which might not be the best
+	// idea ever), in order to ensure index based comparison consistency
+	sort.Sort(expectation)
+	sort.Sort(result)
+
+	for i, v := range expectation {
+		if v.StrValue != result[i].StrValue {
+			t.Logf("Expected [%v] got [%v]", *v, *result[i])
+			t.Fail()
+		}
+
+		if len(v.Path) != len(result[i].Path) {
+			t.Logf("Expected Path length of [%v] got [%v]", len(v.Path), len(result[i].Path))
+			t.FailNow()
+		}
+
+		for j, p := range v.Path {
+			if p != result[i].Path[j] {
+				t.Logf("Expected path term [%v] got [%v]", p, result[i].Path[j])
+				t.Fail()
+			}
+		}
+
+	}
+}
+
+func testAnalyzeStructShouldFail(t *testing.T, expectation, result sortableEnvValues, err error) {
+	if err == nil {
+		t.Logf("Expected an error, got nothing")
+		t.Fail()
+	}
+}
+
+func TestAnalyzeStruct(t *testing.T) {
+	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+
+	testCases := []struct {
+		Label       string
+		Source      interface{}
+		Expectation []*envValue
+		Env         map[string]string
+		Then        testAnalyzeStructThenHook
+	}{
+		{
+			"WithBasicConfiguration",
+			&basicAppConfig{},
+			[]*envValue{
+				&envValue{"FOOO", path{"StringValue"}},
+				&envValue{"10", path{"IntValue"}},
+				&envValue{"true", path{"BoolValue"}},
+			},
+			map[string]string{
+				"STRING_VALUE": "FOOO",
+				"INT_VALUE":    "10",
+				"BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithEmbeddedStruct",
+			&struct {
+				basicAppConfig
+				FloatValue float32
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"StringValue"}},
+				&envValue{"10", path{"IntValue"}},
+				&envValue{"true", path{"BoolValue"}},
+				&envValue{"42.1", path{"FloatValue"}},
+			},
+			map[string]string{
+				"STRING_VALUE": "FOOO",
+				"INT_VALUE":    "10",
+				"BOOL_VALUE":   "true",
+				"FLOAT_VALUE":  "42.1",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithNestedStructValue",
+			&struct {
+				Config basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "StringValue"}},
+				&envValue{"10", path{"Config", "IntValue"}},
+				&envValue{"true", path{"Config", "BoolValue"}},
+			},
+			map[string]string{
+				"CONFIG_STRING_VALUE": "FOOO",
+				"CONFIG_INT_VALUE":    "10",
+				"CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithDoubleNestedStructValue",
+			&struct {
+				Nested struct {
+					Config basicAppConfig
+				}
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Nested", "Config", "StringValue"}},
+				&envValue{"10", path{"Nested", "Config", "IntValue"}},
+				&envValue{"true", path{"Nested", "Config", "BoolValue"}},
+			},
+			map[string]string{
+				"NESTED_CONFIG_STRING_VALUE": "FOOO",
+				"NESTED_CONFIG_INT_VALUE":    "10",
+				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithNestedStructPtr",
+			&struct {
+				Config *basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "StringValue"}},
+				&envValue{"10", path{"Config", "IntValue"}},
+				&envValue{"true", path{"Config", "BoolValue"}},
+			},
+			map[string]string{
+				"CONFIG_STRING_VALUE": "FOOO",
+				"CONFIG_INT_VALUE":    "10",
+				"CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithDoubleNestedStructPtr",
+			&struct {
+				Nested *struct {
+					Config *basicAppConfig
+				}
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Nested", "Config", "StringValue"}},
+				&envValue{"10", path{"Nested", "Config", "IntValue"}},
+				&envValue{"true", path{"Nested", "Config", "BoolValue"}},
+			},
+			map[string]string{
+				"NESTED_CONFIG_STRING_VALUE": "FOOO",
+				"NESTED_CONFIG_INT_VALUE":    "10",
+				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithDoubleNestedStructMixed",
+			&struct {
+				Nested *struct {
+					Config basicAppConfig
+				}
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Nested", "Config", "StringValue"}},
+				&envValue{"10", path{"Nested", "Config", "IntValue"}},
+				&envValue{"true", path{"Nested", "Config", "BoolValue"}},
+			},
+			map[string]string{
+				"NESTED_CONFIG_STRING_VALUE": "FOOO",
+				"NESTED_CONFIG_INT_VALUE":    "10",
+				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithPtrValue",
+			&struct {
+				IntValue *int
+			}{},
+			[]*envValue{
+				&envValue{"10", path{"IntValue"}},
+			},
+			map[string]string{
+				"INT_VALUE": "10",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithNestedPtrValue",
+			&struct {
+				Config struct {
+					IntValue *int
+				}
+			}{},
+			[]*envValue{
+				&envValue{"10", path{"Config", "IntValue"}},
+			},
+			map[string]string{
+				"CONFIG_INT_VALUE": "10",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithNestedPtrValue",
+			&struct {
+				Config struct {
+					IntValue *int
+				}
+			}{},
+			[]*envValue{
+				&envValue{"10", path{"Config", "IntValue"}},
+			},
+			map[string]string{
+				"CONFIG_INT_VALUE": "10",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithPtrPtrToValue",
+			&struct {
+				Config **int
+			}{},
+			[]*envValue{
+				&envValue{"10", path{"Config"}},
+			},
+			map[string]string{
+				"CONFIG": "10",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithPtrPtrToStruct",
+			&struct {
+				Config **basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "StringValue"}},
+				&envValue{"10", path{"Config", "IntValue"}},
+				&envValue{"true", path{"Config", "BoolValue"}},
+			},
+			map[string]string{
+				"CONFIG_STRING_VALUE": "FOOO",
+				"CONFIG_INT_VALUE":    "10",
+				"CONFIG_BOOL_VALUE":   "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithMapOfValues",
+			&struct {
+				Config map[string]string
+			}{},
+			[]*envValue{
+				&envValue{"FOO", path{"Config", "foo"}},
+				&envValue{"MEH", path{"Config", "bar"}},
+				&envValue{"BAR", path{"Config", "biz"}},
+			},
+			map[string]string{
+				"CONFIG_FOO": "FOO",
+				"CONFIG_BAR": "MEH",
+				"CONFIG_BIZ": "BAR",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithMapOfStructValues",
+			&struct {
+				Config map[string]basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOO", path{"Config", "foo", "StringValue"}},
+				&envValue{"MEH", path{"Config", "bar", "StringValue"}},
+				&envValue{"BAR", path{"Config", "biz", "StringValue"}},
+			},
+			map[string]string{
+				"CONFIG_FOO_STRING_VALUE": "FOO",
+				"CONFIG_BAR_STRING_VALUE": "MEH",
+				"CONFIG_BIZ_STRING_VALUE": "BAR",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithMapOfStructPtr",
+			&struct {
+				Config map[string]*basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOO", path{"Config", "foo", "StringValue"}},
+				&envValue{"MEH", path{"Config", "bar", "StringValue"}},
+				&envValue{"BAR", path{"Config", "biz", "StringValue"}},
+			},
+			map[string]string{
+				"CONFIG_FOO_STRING_VALUE": "FOO",
+				"CONFIG_BAR_STRING_VALUE": "MEH",
+				"CONFIG_BIZ_STRING_VALUE": "BAR",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithMapOfMapOfPtrStruct",
+			&struct {
+				Config map[int]map[string]*basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOO", path{"Config", "0", "foo", "StringValue"}},
+				&envValue{"MEH", path{"Config", "1", "bar", "StringValue"}},
+				&envValue{"BAR", path{"Config", "0", "biz", "StringValue"}},
+			},
+			map[string]string{
+				"CONFIG_0_FOO_STRING_VALUE": "FOO",
+				"CONFIG_1_BAR_STRING_VALUE": "MEH",
+				"CONFIG_0_BIZ_STRING_VALUE": "BAR",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithSliceToValue",
+			&struct {
+				Config []int
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0"}},
+				&envValue{"10", path{"Config", "1"}},
+				&envValue{"true", path{"Config", "2"}},
+			},
+			map[string]string{
+				"CONFIG_0": "FOOO",
+				"CONFIG_1": "10",
+				"CONFIG_2": "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithSliceToValueAndInvalidKey",
+			&struct {
+				Config []int
+			}{},
+			[]*envValue{},
+			map[string]string{
+				"CONFIG_0":      "FOOO",
+				"CONFIG_1":      "10",
+				"CONFIG_PATATE": "true",
+			},
+			testAnalyzeStructShouldFail,
+		},
+		{
+			"WithAnArrayToValue",
+			&struct {
+				Config [10]int
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0"}},
+				&envValue{"10", path{"Config", "1"}},
+				&envValue{"true", path{"Config", "2"}},
+			},
+			map[string]string{
+				"CONFIG_0": "FOOO",
+				"CONFIG_1": "10",
+				"CONFIG_2": "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithAnArrayAndAnOutOfBoundIndex",
+			&struct {
+				Config [10]int
+			}{},
+			[]*envValue{},
+			map[string]string{
+				"CONFIG_11": "10",
+			},
+			testAnalyzeStructShouldFail,
+		},
+		{
+			"WithAnArrayToValue",
+			&struct {
+				Config [10]int
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0"}},
+				&envValue{"10", path{"Config", "1"}},
+				&envValue{"true", path{"Config", "2"}},
+			},
+			map[string]string{
+				"CONFIG_0": "FOOO",
+				"CONFIG_1": "10",
+				"CONFIG_2": "true",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithASliceToStruct",
+			&struct {
+				Config []basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0", "StringValue"}},
+				&envValue{"10", path{"Config", "0", "IntValue"}},
+				&envValue{"MIMI", path{"Config", "1", "StringValue"}},
+				&envValue{"15", path{"Config", "1", "IntValue"}},
+			},
+			map[string]string{
+				"CONFIG_0_STRING_VALUE": "FOOO",
+				"CONFIG_0_INT_VALUE":    "10",
+				"CONFIG_1_STRING_VALUE": "MIMI",
+				"CONFIG_1_INT_VALUE":    "15",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithASliceToASliceToStruct",
+			&struct {
+				Config [][]basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0", "0", "StringValue"}},
+				&envValue{"10", path{"Config", "0", "0", "IntValue"}},
+				&envValue{"MIMI", path{"Config", "1", "1", "StringValue"}},
+				&envValue{"15", path{"Config", "1", "1", "IntValue"}},
+			},
+			map[string]string{
+				"CONFIG_0_0_STRING_VALUE": "FOOO",
+				"CONFIG_0_0_INT_VALUE":    "10",
+				"CONFIG_1_1_STRING_VALUE": "MIMI",
+				"CONFIG_1_1_INT_VALUE":    "15",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+		{
+			"WithASliceToAMapToStruct",
+			&struct {
+				Config []map[string]basicAppConfig
+			}{},
+			[]*envValue{
+				&envValue{"FOOO", path{"Config", "0", "foo", "StringValue"}},
+				&envValue{"10", path{"Config", "0", "foo", "IntValue"}},
+				&envValue{"MIMI", path{"Config", "1", "bar", "StringValue"}},
+				&envValue{"15", path{"Config", "1", "bar", "IntValue"}},
+			},
+			map[string]string{
+				"CONFIG_0_FOO_STRING_VALUE": "FOOO",
+				"CONFIG_0_FOO_INT_VALUE":    "10",
+				"CONFIG_1_BAR_STRING_VALUE": "MIMI",
+				"CONFIG_1_BAR_INT_VALUE":    "15",
+			},
+			testAnalyzeStructShouldSucceed,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			setupEnv(testCase.Env)
+			res, err := subject.analyzeStruct(
+				reflect.TypeOf(testCase.Source).Elem(),
+				path{},
+			)
+			testCase.Then(t, testCase.Expectation, res, err)
+			cleanupEnv(testCase.Env)
+		})
+	}
+
+}
+
+func TestEnvVarFromPath(t *testing.T) {
+	testCases := []struct {
+		Label       string
+		Prefix      string
+		Separator   string
+		Path        []string
+		Expectation string
+	}{
+		{"BlankPrefix", "", "_", []string{"Foo"}, "FOO"},
+		{"NonBlankPrefix", "YOUPI", "_", []string{"Foo"}, "YOUPI_FOO"},
+		{
+			"CamelCasedPathMembers",
+			"YOUPI",
+			"_",
+			[]string{"Foo", "IamGroot", "IAmBatman"},
+			"YOUPI_FOO_IAM_GROOT_I_AM_BATMAN",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			subject := &envSource{
+				testCase.Prefix,
+				testCase.Separator,
+				map[reflect.Type]flaeg.Parser{},
+			}
+
+			result := subject.envVarFromPath(testCase.Path)
+
+			if result != testCase.Expectation {
+				t.Logf("Expected [%s] got [%s]\n", testCase.Expectation, result)
+				t.Fail()
+			}
+		})
+	}
+
+}
+
+func TestNextLevelKeys(t *testing.T) {
+	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+	testCases := []struct {
+		Label       string
+		Prefix      string
+		EnvVars     []string
+		Expectation []string
+	}{
+		{
+			"WithPrefix",
+			"CONFIG_APP",
+			[]string{
+				"CONFIG_APP_BATMAN_FOO",
+				"CONFIG_APP_ROBIN_FOO",
+				"CONFIG_APP_JOCKER_FOO",
+			},
+			[]string{
+				"CONFIG_APP_BATMAN",
+				"CONFIG_APP_ROBIN",
+				"CONFIG_APP_JOCKER",
+			},
+		},
+		{
+			"WithDuplicates",
+			"CONFIG_APP",
+			[]string{
+				"CONFIG_APP_BATMAN_FOO",
+				"CONFIG_APP_ROBIN_FOO",
+				"CONFIG_APP_JOCKER_FOO",
+				"CONFIG_APP_BATMAN_BAR",
+			},
+			[]string{
+				"CONFIG_APP_BATMAN",
+				"CONFIG_APP_ROBIN",
+				"CONFIG_APP_JOCKER",
+				"CONFIG_APP_BATMAN",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			res := subject.nextLevelKeys(testCase.Prefix, testCase.EnvVars)
+			for i, exp := range testCase.Expectation {
+				if exp != res[i] {
+					t.Logf("Unexpected value, expected [%s] got [%s]", exp, res[i])
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func TestEnvVarsWithPrefix(t *testing.T) {
+
+	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+
+	testCases := []struct {
+		Label       string
+		Prefix      string
+		Env         map[string]string
+		Expectation []string
+	}{
+		{
+			"WithPrefix",
+			"APP",
+			map[string]string{
+				"STRING_VALUE":   "FOOO",
+				"INT_VALUE":      "10",
+				"BOOL_VALUE":     "true",
+				"APP_BOOL_VALUE": "true",
+				"APP_BAR_VALUE":  "true",
+			},
+			[]string{"APP_BOOL_VALUE", "APP_BAR_VALUE"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			setupEnv(testCase.Env)
+			res := subject.envVarsWithPrefix(testCase.Prefix)
+			for i, envVar := range testCase.Expectation {
+				if envVar != res[i] {
+					t.Logf("Invalid env variableName, expected [%s] got [%s]", envVar, res[i])
+					t.Fail()
+				}
+			}
+			cleanupEnv(testCase.Env)
+		})
+	}
+}
+
+func TestUnique(t *testing.T) {
+	testCases := []struct {
+		Label       string
+		In          []string
+		Expectation []string
+	}{
+		{
+			"WithDuplicates",
+			[]string{"FOO", "BAR", "BIZ", "FOO", "BIZ"},
+			[]string{"FOO", "BAR", "BIZ"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			res := unique(testCase.In)
+			for i, val := range testCase.Expectation {
+				if res[i] != val {
+					t.Logf("Invalid result: expected [%s] got [%s]\n", val, res[i])
+					t.Fail()
+				}
+			}
+		})
+	}
+}
+
+func TestKeyFromEnvVar(t *testing.T) {
+	subject := &envSource{"", "_", map[reflect.Type]flaeg.Parser{}}
+	testCases := []struct {
+		Label       string
+		Prefix      string
+		EnvVar      string
+		Expectation string
+	}{
+		{"WithPrefix", "CONFIG_APP", "CONFIG_APP_BATMAN", "batman"},
+		{"WithPrefixAndSuffix", "CONFIG_APP", "CONFIG_APP_BATMAN_FOO", "batman"},
+		{"WithoutPrefix", "", "BATMAN", "batman"},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			if res := subject.keyFromEnvVar(testCase.EnvVar, testCase.Prefix); res != testCase.Expectation {
+				t.Logf("Unexpected value, expected [%s] got [%s]", testCase.Expectation, res)
+				t.Fail()
+			}
+		})
+	}
+}
+
+// Dummy string parser, to enable test writing
+type testStringParser string
+
+func (s testStringParser) String() string {
+	return string(s)
+}
+
+func (s *testStringParser) Set(val string) error {
+	*s = testStringParser(val)
+	return nil
+}
+
+func (s testStringParser) SetValue(val interface{}) {}
+
+func (s testStringParser) Get() interface{} {
+	return nil
+}
+
+func TestAssignValues(t *testing.T) {
+	var stringParserValue testStringParser
+	subject := &envSource{
+		"",
+		"_",
+		map[reflect.Type]flaeg.Parser{
+			reflect.TypeOf(""): &stringParserValue,
+		},
+	}
+
+	testCases := []struct {
+		Label       string
+		Value       interface{}
+		Values      []*envValue
+		Expectation interface{}
+	}{
+		{
+			"BasicStuct",
+			&struct {
+				StringValue      string
+				OtherStringValue string
+			}{},
+			[]*envValue{
+				&envValue{"FOO", path{"StringValue"}},
+				&envValue{"BAR", path{"OtherStringValue"}},
+			},
+			&struct {
+				StringValue      string
+				OtherStringValue string
+			}{"FOO", "BAR"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Label, func(t *testing.T) {
+			err := subject.assignValues(reflect.ValueOf(testCase.Value).Elem(), testCase.Values)
+			if err != nil {
+				t.Logf("Expected no error, got %s", err.Error())
+				t.Fail()
+			}
+
+			if !reflect.DeepEqual(testCase.Expectation, testCase.Value) {
+				t.Logf("Incorrect assignation, expected %v got %v", testCase.Expectation, testCase.Value)
+				t.Fail()
+			}
+		})
+	}
+}

--- a/kv_test.go
+++ b/kv_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/abronan/valkeyrie/store"
 	"github.com/containous/flaeg"
+	"github.com/containous/flaeg/parse"
+	"github.com/docker/libkv/store"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -219,7 +221,7 @@ func TestKvSourceEmpty(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	//Test
@@ -249,7 +251,7 @@ func TestKvSourceEmpty(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(expected, rootCmd.Config) {
@@ -316,7 +318,7 @@ func TestIntegrationMapstructureWithDecodeHookPointer(t *testing.T) {
 		PtrStruct1: &Struct1{
 			S1Int: 28,
 		},
-		DurationField: flaeg.Duration(28 * time.Nanosecond),
+		DurationField: parse.Duration(28 * time.Nanosecond),
 	}
 
 	if !reflect.DeepEqual(expected, config) {
@@ -344,7 +346,7 @@ func TestIntegrationMapstructureInitiatedPtrReset(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(28 * time.Second),
+		DurationField: parse.Duration(28 * time.Second),
 	}
 
 	//test
@@ -367,7 +369,7 @@ func TestIntegrationMapstructureInitiatedPtrReset(t *testing.T) {
 			S1Int:    24,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(28 * time.Second),
+		DurationField: parse.Duration(28 * time.Second),
 	}
 
 	if !reflect.DeepEqual(expected, config) {
@@ -412,7 +414,7 @@ func TestParseKvSourceTrivial(t *testing.T) {
 		PtrStruct1: &Struct1{
 			S1Int: 28,
 		},
-		DurationField: flaeg.Duration(28 * time.Nanosecond),
+		DurationField: parse.Duration(28 * time.Nanosecond),
 	}
 
 	if !reflect.DeepEqual(expected, rootCmd.Config) {
@@ -455,7 +457,7 @@ func TestLoadConfigKvSourceNestedPtrsNil(t *testing.T) {
 			S1String:     "S1StringInitConfig",
 			S1PtrStruct3: &Struct3{},
 		},
-		DurationField: flaeg.Duration(21 * time.Second),
+		DurationField: parse.Duration(21 * time.Second),
 	}
 
 	if !reflect.DeepEqual(expected, config) {
@@ -505,7 +507,7 @@ func TestParseKvSourceNestedPtrsNil(t *testing.T) {
 			S1String:     "S1StringInitConfig",
 			S1PtrStruct3: &Struct3{},
 		},
-		DurationField: flaeg.Duration(21 * time.Second),
+		DurationField: parse.Duration(21 * time.Second),
 	}
 
 	if !reflect.DeepEqual(expected, rootCmd.Config) {
@@ -614,7 +616,7 @@ func TestCollateKvPairsNestedPointers(t *testing.T) {
 			S1String:     "S1StringInitConfig",
 			S1PtrStruct3: &Struct3{},
 		},
-		DurationField: flaeg.Duration(21 * time.Second),
+		DurationField: parse.Duration(21 * time.Second),
 	}
 
 	//test

--- a/kv_test.go
+++ b/kv_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/abronan/valkeyrie/store"
 	"github.com/containous/flaeg"
 	"github.com/containous/flaeg/parse"
-	"github.com/docker/libkv/store"
 	"github.com/mitchellh/mapstructure"
 )
 

--- a/staert_test.go
+++ b/staert_test.go
@@ -11,13 +11,14 @@ import (
 	"time"
 
 	"github.com/containous/flaeg"
+	"github.com/containous/flaeg/parse"
 )
 
 //StructPtr : Struct with pointers
 type StructPtr struct {
 	PtrStruct1    *Struct1       `description:"Enable Struct1"`
 	PtrStruct2    *Struct2       `description:"Enable Struct1"`
-	DurationField flaeg.Duration `description:"Duration Field"`
+	DurationField parse.Duration `description:"Duration Field"`
 }
 
 //Struct1 : Struct with pointer
@@ -49,7 +50,7 @@ func TestFlaegSourceNoArgs(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -93,7 +94,7 @@ func TestFlaegSourceNoArgs(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -110,7 +111,7 @@ func TestFlaegSourcePtrUnderPtrArgs(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -157,7 +158,7 @@ func TestFlaegSourcePtrUnderPtrArgs(t *testing.T) {
 				S3Float64: 11.11,
 			},
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -179,7 +180,7 @@ func TestFlaegSourceFieldUnderPtrUnderPtrArgs(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -226,7 +227,7 @@ func TestFlaegSourceFieldUnderPtrUnderPtrArgs(t *testing.T) {
 				S3Float64: 55.55,
 			},
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -243,7 +244,7 @@ func TestTomlSourceNothing(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -285,7 +286,7 @@ func TestTomlSourceNothing(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -302,7 +303,7 @@ func TestTomlSourceTrivial(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -345,7 +346,7 @@ func TestTomlSourceTrivial(t *testing.T) {
 			S1String: "S1StringDefaultPointersConfig",
 			S1Bool:   true,
 		},
-		DurationField: flaeg.Duration(28 * time.Second),
+		DurationField: parse.Duration(28 * time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -363,7 +364,7 @@ func TestTomlSourcePointer(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -410,7 +411,7 @@ func TestTomlSourcePointer(t *testing.T) {
 			S2String: "S2StringDefaultPointersConfig",
 			S2Bool:   false,
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -425,7 +426,7 @@ func TestTomlSourceFieldUnderPointer(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -468,7 +469,7 @@ func TestTomlSourceFieldUnderPointer(t *testing.T) {
 			S1String: "S1StringDefaultPointersConfig",
 			S1Bool:   true,
 		},
-		DurationField: flaeg.Duration(42 * time.Second),
+		DurationField: parse.Duration(42 * time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, expected) {
@@ -486,7 +487,7 @@ func TestTomlSourcePointerUnderPointer(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -532,7 +533,7 @@ func TestTomlSourcePointerUnderPointer(t *testing.T) {
 				S3Float64: 11.11,
 			},
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -551,7 +552,7 @@ func TestTomlSourceFieldUnderPointerUnderPointer(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -596,7 +597,7 @@ func TestTomlSourceFieldUnderPointerUnderPointer(t *testing.T) {
 				S3Float64: 28.28,
 			},
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -613,7 +614,7 @@ func TestMergeTomlNothingFlaegNoArgs(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -659,7 +660,7 @@ func TestMergeTomlNothingFlaegNoArgs(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -677,7 +678,7 @@ func TestMergeTomlFieldUnderPointerUnderPointerFlaegNoArgs(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -726,7 +727,7 @@ func TestMergeTomlFieldUnderPointerUnderPointerFlaegNoArgs(t *testing.T) {
 				S3Float64: 28.28,
 			},
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -744,7 +745,7 @@ func TestMergeTomlTrivialFlaegOverwriteField(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -790,7 +791,7 @@ func TestMergeTomlTrivialFlaegOverwriteField(t *testing.T) {
 			S1String: "S1StringDefaultPointersConfig",
 			S1Bool:   true,
 		},
-		DurationField: flaeg.Duration(28 * time.Second),
+		DurationField: parse.Duration(28 * time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -810,7 +811,7 @@ func TestMergeTomlPointerUnderPointerFlaegManyArgs(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -869,7 +870,7 @@ func TestMergeTomlPointerUnderPointerFlaegManyArgs(t *testing.T) {
 			S2String: "S2StringFlaeg",
 			S2Bool:   false,
 		},
-		DurationField: flaeg.Duration(55 * time.Second),
+		DurationField: parse.Duration(55 * time.Second),
 	}
 	if !reflect.DeepEqual(rootCmd.Config, check) {
 		t.Errorf("\nexpected\t: %+v\ngot\t\t\t: %+v\n", check, rootCmd.Config)
@@ -886,7 +887,7 @@ func TestMergeFlaegNoArgsTomlNothing(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -932,7 +933,7 @@ func TestMergeFlaegNoArgsTomlNothing(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -950,7 +951,7 @@ func TestMergeFlaegFieldUnderPointerUnderPointerTomlNothing(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -1000,7 +1001,7 @@ func TestMergeFlaegFieldUnderPointerUnderPointerTomlNothing(t *testing.T) {
 				S3Float64: 55.55,
 			},
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 
 	if !reflect.DeepEqual(rootCmd.Config, check) {
@@ -1018,7 +1019,7 @@ func TestMergeFlaegManyArgsTomlOverwriteField(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -1068,7 +1069,7 @@ func TestMergeFlaegManyArgsTomlOverwriteField(t *testing.T) {
 			S1String: "S1StringDefaultPointersConfig",
 			S1Bool:   true,
 		},
-		DurationField: flaeg.Duration(28 * time.Second),
+		DurationField: parse.Duration(28 * time.Second),
 		PtrStruct2: &Struct2{
 			S2Int64:  22,
 			S2String: "S2StringFlaeg",
@@ -1091,7 +1092,7 @@ func TestRunFlaegFieldUnderPtrUnderPtr1Command(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -1128,7 +1129,7 @@ func TestRunFlaegFieldUnderPtrUnderPtr1Command(t *testing.T) {
 						S3Float64: 55.55,
 					},
 				},
-				DurationField: flaeg.Duration(time.Second),
+				DurationField: parse.Duration(time.Second),
 			}
 
 			if !reflect.DeepEqual(config, check) {
@@ -1168,7 +1169,7 @@ func TestRunFlaegFieldUnderPtrUnderPtr2Command(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -1207,7 +1208,7 @@ func TestRunFlaegFieldUnderPtrUnderPtr2Command(t *testing.T) {
 						S3Float64: 55.55,
 					},
 				},
-				DurationField: flaeg.Duration(time.Second),
+				DurationField: parse.Duration(time.Second),
 			}
 
 			if !reflect.DeepEqual(config, check) {
@@ -1263,7 +1264,7 @@ func TestRunFlaegVersion2CommandCallVersion(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -1305,7 +1306,7 @@ func TestRunFlaegVersion2CommandCallVersion(t *testing.T) {
 						S3Float64: 55.55,
 					},
 				},
-				DurationField: flaeg.Duration(time.Second),
+				DurationField: parse.Duration(time.Second),
 			}
 
 			if !reflect.DeepEqual(config, check) {
@@ -1361,7 +1362,7 @@ func TestRunMergeFlaegToml2CommmandCallRootCmd(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -1401,7 +1402,7 @@ func TestRunMergeFlaegToml2CommmandCallRootCmd(t *testing.T) {
 					S1String: "S1StringDefaultPointersConfig",
 					S1Bool:   true,
 				},
-				DurationField: flaeg.Duration(28 * time.Second),
+				DurationField: parse.Duration(28 * time.Second),
 				PtrStruct2: &Struct2{
 					S2Int64:  22,
 					S2String: "S2StringFlaeg",
@@ -1465,7 +1466,7 @@ func TestTomlSourceErrorFileNotFound(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -1636,7 +1637,7 @@ func TestRunWithoutLoadConfig(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	defaultPointersConfig := &StructPtr{
 		PtrStruct1: &Struct1{
@@ -1681,7 +1682,7 @@ func TestRunWithoutLoadConfig(t *testing.T) {
 			S1Int:    1,
 			S1String: "S1StringInitConfig",
 		},
-		DurationField: flaeg.Duration(time.Second),
+		DurationField: parse.Duration(time.Second),
 	}
 	if !reflect.DeepEqual(rootCmd.Config, check) {
 		t.Errorf("\nexpected\t: %+v\ngot\t\t\t: %+v\n", check, rootCmd.Config)


### PR DESCRIPTION
Every sources in staert walk the config object to populate.
This PR handles 2 edge cases : 

- `type.Interface` 
`reflect.Numfield` gives a `panic` when it runs on an `Interface`. For now, skip the Interface types (same as flaeg)

- Unexported fields
we skip unexported fields, since they can't be set. (same as flaeg)

This raises the question of extracting the reflection logic to walk the config types.