### PR TITLE
Add Environment Variable Source to Staert

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -33,6 +33,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/fatih/camelcase"
+  packages = ["."]
+  revision = "44e46d280b43ec1531bb25252440e34f1b800b65"
+
+[[projects]]
+  branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
   revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
@@ -61,6 +67,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2c78b77b71078e30b78c5b9c38f85abd0867ed09b60445c6dde538f93de3e753"
+  inputs-digest = "5a20b17b253088a8fa99c458ef4cbff43d64e82e2163c9760a72359662219895"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/envsource.go
+++ b/envsource.go
@@ -1,0 +1,402 @@
+package staert
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/containous/flaeg"
+	"github.com/containous/flaeg/parse"
+	"github.com/fatih/camelcase"
+)
+
+var mutex sync.Mutex
+
+// EnvSource implements SourceLoader
+// Enables to populate configuration struct with information extracted from
+// process's environment variables. Variables names are like %PREFIX%%SEP%%FIELD_NAME%
+// It supports pointer to values and struct, however not slices and arrays..
+type EnvSource struct {
+	prefix    string
+	separator string
+	parsers   map[reflect.Type]parse.Parser
+}
+
+type envValue struct {
+	strValue string
+	path     []string
+}
+
+// NewEnvSource constructs a new instance of EnvSource
+func NewEnvSource(prefix, separator string, parsers map[reflect.Type]parse.Parser) *EnvSource {
+	return &EnvSource{prefix: prefix, separator: separator, parsers: parsers}
+}
+
+// Parse parse and load config structure
+func (e *EnvSource) Parse(cmd *flaeg.Command) (*flaeg.Command, error) {
+	return cmd, e.LoadConfig(cmd.Config)
+}
+
+// LoadConfig load a configuration from a configuration structure
+func (e *EnvSource) LoadConfig(config interface{}) error {
+	configVal := reflect.ValueOf(config).Elem()
+
+	values, err := e.analyzeStruct(configVal.Type(), nil)
+	if err != nil {
+		return err
+	}
+
+	return e.assignValues(configVal, values, nil)
+}
+
+// Recursively scan the given config structure type information
+// and look for defined environment variables.
+func (e *EnvSource) analyzeStruct(configType reflect.Type, currentPath []string) ([]*envValue, error) {
+	var res []*envValue
+
+	for i := 0; i < configType.NumField(); i++ {
+		field := configType.Field(i)
+
+		// TODO: Handle this case;
+		// find the underlying struct and process it.
+		if field.Type.Kind() == reflect.Interface {
+			// skip fields of kind interface
+			continue
+		}
+
+		// If we're facing an embedded struct
+		if field.Anonymous {
+			values, err := e.analyzeValue(field.Type, currentPath)
+			if err != nil {
+				return nil, err
+			}
+
+			res = append(res, values...)
+			continue
+		}
+
+		// unexported fields must be handled after embedded structs (field.Anonymous)
+		// because the PkgPath is also null for them.
+		// ref: https://github.com/golang/go/issues/21122
+		if field.PkgPath != "" {
+			// field is unexported
+			continue
+		}
+
+		values, err := e.analyzeValue(field.Type, append(currentPath, field.Name))
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, values...)
+	}
+
+	return res, nil
+}
+
+func (e *EnvSource) analyzeValue(valType reflect.Type, fieldPath []string) ([]*envValue, error) {
+	switch valType.Kind() {
+	case reflect.Array, reflect.Slice, reflect.Map:
+		return e.analyzeIndexedType(valType, fieldPath)
+	case reflect.Ptr:
+		return e.analyzeValue(valType.Elem(), fieldPath)
+	case reflect.Struct:
+		return e.analyzeStruct(valType, fieldPath)
+	case reflect.Invalid, reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
+		return nil, nil
+		// Skip these fields, don't throw...
+		// TODO : keep track of the fields ignored by the library to be able to list them.
+		// err = fmt.Errorf("type %s is not supported by EnvSource. fieldPath : %v", valType.Name(), fieldPath)
+	default:
+		return e.loadValue(fieldPath), nil
+	}
+}
+
+func (e *EnvSource) analyzeIndexedType(valType reflect.Type, fieldPath []string) ([]*envValue, error) {
+	prefix := e.envVarFromPath(fieldPath)
+	vars := e.envVarsWithPrefix(prefix)
+	nextKeys := unique(e.nextLevelKeys(prefix, vars))
+
+	var res []*envValue
+	for _, varName := range nextKeys {
+		key := e.keyFromEnvVar(varName, prefix)
+
+		// If we're on an Int based key, we need to be able to convert
+		// detected key to an int
+		if valType.Kind() == reflect.Array || valType.Kind() == reflect.Slice {
+			index, err := strconv.Atoi(key)
+			if err != nil {
+				return nil, fmt.Errorf("invalid key %q for variable %q: %v", key, varName, err)
+			}
+
+			if valType.Kind() == reflect.Array && index >= valType.Len() {
+				return nil, fmt.Errorf("detected key (%s) from variable %s is >= to array length %d",
+					key, varName, valType.Len())
+			}
+		}
+
+		valPath := append(fieldPath, key)
+		keyValues, err := e.analyzeValue(valType.Elem(), valPath)
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, keyValues...)
+	}
+
+	return res, nil
+}
+
+func (e *EnvSource) loadValue(fieldPath []string) []*envValue {
+	variableName := e.envVarFromPath(fieldPath)
+
+	value, ok := os.LookupEnv(variableName)
+	if !ok {
+		return nil
+	}
+
+	clone := make([]string, len(fieldPath))
+	copy(clone, fieldPath)
+
+	return []*envValue{{strValue: value, path: clone}}
+}
+
+func (e *EnvSource) assignValues(configVal reflect.Value, envValues []*envValue, currentPath []string) error {
+	if len(currentPath) > 0 {
+		envValues = filterEnvVarWithPrefix(envValues, currentPath)
+	}
+
+	if configVal.Kind() == reflect.Ptr {
+		if configVal.IsNil() {
+			configVal.Set(reflect.New(configVal.Type().Elem()))
+		}
+		return e.assignValues(configVal.Elem(), envValues, nil)
+	}
+
+	for _, v := range envValues {
+		fieldVal := configVal.FieldByName(v.path[0])
+		if !fieldVal.IsValid() {
+			// skip field that are found invalid
+			continue
+		}
+		switch fieldVal.Kind() {
+
+		case reflect.Ptr, reflect.Struct:
+			err := e.assignValues(fieldVal, []*envValue{v}, []string{v.path[0]})
+			if err != nil {
+				return err
+			}
+		case reflect.Slice, reflect.Array:
+			err := e.assignArrays(fieldVal, envValues, v)
+			if err != nil {
+				return err
+			}
+		case reflect.Map:
+			key := v.path[1]
+			val := v.strValue
+
+			mapType := fieldVal.Type()
+			elemType := mapType.Elem()
+
+			if elemType.Kind() == reflect.Struct {
+				elem := reflect.New(elemType).Elem()
+
+				err := e.assignValues(elem, envValues, v.path[:2])
+				if err != nil {
+					return err
+				}
+
+				err = e.assignMap(fieldVal, key, elem)
+				if err != nil {
+					return err
+				}
+			} else {
+				err := e.assignMap(fieldVal, key, reflect.ValueOf(val))
+				if err != nil {
+					return err
+				}
+			}
+		default:
+			value, err := e.getParsedValue(fieldVal.Type(), v.strValue)
+			if err != nil {
+				return err
+			}
+
+			fieldVal.Set(*value)
+		}
+	}
+
+	return nil
+}
+
+func (e *EnvSource) assignMap(fieldVal reflect.Value, key string, val reflect.Value) error {
+	mapType := fieldVal.Type()
+	if fieldVal.IsNil() {
+		fieldVal.Set(reflect.MakeMap(mapType))
+	}
+
+	elemType := mapType.Elem()
+	keyType := mapType.Key()
+
+	parsedKey, err := e.getParsedValue(keyType, key)
+	if err != nil {
+		return err
+	}
+
+	if val.Kind() == reflect.String {
+		parsedVal, err := e.getParsedValue(elemType, val.String())
+		if err != nil {
+			return err
+		}
+
+		fieldVal.SetMapIndex(*parsedKey, *parsedVal)
+	} else {
+		fieldVal.SetMapIndex(*parsedKey, val)
+	}
+
+	return nil
+}
+
+func (e *EnvSource) assignArrays(fieldVal reflect.Value, envValues []*envValue, currentEnvValue *envValue) error {
+	arrayType := fieldVal.Type()
+	slice := reflect.Zero(reflect.SliceOf(arrayType.Elem()))
+	if !fieldVal.IsNil() {
+		slice = reflect.Indirect(fieldVal)
+		fieldVal.Set(slice)
+	}
+	elemType := arrayType.Elem()
+
+	if elemType.Kind() != reflect.Struct && elemType.Kind() != reflect.Ptr {
+		parsedVal, err := e.getParsedValue(elemType, currentEnvValue.strValue)
+		if err != nil {
+			return err
+		}
+
+		slice = reflect.Append(slice, *parsedVal)
+		fieldVal.Set(slice)
+	} else {
+		if index, err := strconv.Atoi(currentEnvValue.path[1]); err == nil {
+			// grow the slice if needed
+			if slice.Len() <= index {
+				newSlice := reflect.MakeSlice(slice.Type(), index+1, index+1)
+				reflect.Copy(newSlice, slice)
+				slice = newSlice
+			}
+
+			// get item at env value specified index.
+			existingValue := slice.Index(index)
+			err = e.assignValues(existingValue, envValues, currentEnvValue.path[:2])
+			if err != nil {
+				return err
+			}
+
+			fieldVal.Set(slice)
+		}
+	}
+	return nil
+}
+
+func (e *EnvSource) getParsedValue(valType reflect.Type, strValue string) (*reflect.Value, error) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	parser, ok := e.parsers[valType]
+	if !ok {
+		return nil, fmt.Errorf("parser not found for type %v and value %q", valType, strValue)
+	}
+
+	err := parser.Set(strValue)
+	if err != nil {
+		return nil, err
+	}
+
+	value := reflect.ValueOf(parser.Get())
+	return &value, nil
+}
+
+func (e *EnvSource) nextLevelKeys(prefix string, envVars []string) []string {
+	res := make([]string, 0, len(envVars))
+
+	for _, envVar := range envVars {
+		nextKey := strings.SplitN(
+			strings.TrimPrefix(envVar, prefix+e.separator),
+			e.separator, 2,
+		)[0]
+		res = append(res, prefix+e.separator+nextKey)
+	}
+
+	return res
+}
+
+func (e *EnvSource) envVarsWithPrefix(prefix string) []string {
+	var res []string
+
+	for _, rawVar := range os.Environ() {
+		if strings.HasPrefix(rawVar, prefix) {
+			varName := strings.SplitN(rawVar, "=", 2)[0]
+			res = append(res, varName)
+		}
+	}
+
+	return res
+}
+
+func (e *EnvSource) keyFromEnvVar(fullVar, prefix string) string {
+	return strings.ToLower(
+		strings.SplitN(
+			strings.TrimPrefix(fullVar, prefix+e.separator),
+			e.separator, 2,
+		)[0],
+	)
+}
+
+func (e *EnvSource) envVarFromPath(currentPath []string) string {
+	if e.prefix != "" {
+		currentPath = append([]string{e.prefix}, currentPath...)
+	}
+
+	s := make([]string, 0, len(currentPath))
+	for _, word := range currentPath {
+		s = append(s, camelcase.Split(word)...)
+	}
+
+	return strings.ToUpper(strings.Join(s, e.separator))
+}
+
+func unique(in []string) []string {
+	collector := make(map[string]struct{})
+
+	var res []string
+	for _, v := range in {
+		if _, ok := collector[v]; ok {
+			continue
+		}
+
+		collector[v] = struct{}{}
+		res = append(res, v)
+	}
+
+	return res
+}
+
+func filterEnvVarWithPrefix(envValues []*envValue, startFilter []string) []*envValue {
+	startFilterPath := strings.Join(startFilter, "")
+
+	var res []*envValue
+	for _, currentEnvValue := range envValues {
+		if len(currentEnvValue.path) >= len(startFilter) {
+			currentPath := strings.Join(currentEnvValue.path[0:len(startFilter)], "")
+			if startFilterPath == currentPath {
+				newEnvValue := &envValue{
+					strValue: currentEnvValue.strValue,
+					path:     currentEnvValue.path[len(startFilter):],
+				}
+				res = append(res, newEnvValue)
+			}
+		}
+	}
+	return res
+}

--- a/envsource_analyzestruct_test.go
+++ b/envsource_analyzestruct_test.go
@@ -96,23 +96,23 @@ func TestAnalyzeStruct(t *testing.T) {
 
 	testCases := []struct {
 		desc     string
+		env      map[string]string
 		source   interface{}
 		expected []*envValue
-		env      map[string]string
 		then     func(t *testing.T, expectation, result sortableEnvValues, err error)
 	}{
 		{
 			desc:   "should succeed with basic struct",
 			source: &basicAppConfig{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"StringValue"}},
-				{strValue: "10", path: []string{"IntValue"}},
-				{strValue: "true", path: []string{"BoolValue"}},
-			},
 			env: map[string]string{
 				"STRING_VALUE": "FOOO",
 				"INT_VALUE":    "10",
 				"BOOL_VALUE":   "true",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"StringValue"}},
+				{strValue: "10", path: []string{"IntValue"}},
+				{strValue: "true", path: []string{"BoolValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
@@ -122,12 +122,12 @@ func TestAnalyzeStruct(t *testing.T) {
 				unexported string
 				IntValue   int
 			}{},
-			expected: []*envValue{
-				{strValue: "10", path: []string{"IntValue"}},
-			},
 			env: map[string]string{
 				"UNEXPORTED": "FOOO",
 				"INT_VALUE":  "10",
+			},
+			expected: []*envValue{
+				{strValue: "10", path: []string{"IntValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
@@ -137,32 +137,32 @@ func TestAnalyzeStruct(t *testing.T) {
 				basicAppConfig
 				FloatValue float32
 			}{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"StringValue"}},
-				{strValue: "10", path: []string{"IntValue"}},
-				{strValue: "true", path: []string{"BoolValue"}},
-				{strValue: "42.1", path: []string{"FloatValue"}},
-			},
 			env: map[string]string{
 				"STRING_VALUE": "FOOO",
 				"INT_VALUE":    "10",
 				"BOOL_VALUE":   "true",
 				"FLOAT_VALUE":  "42.1",
 			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"StringValue"}},
+				{strValue: "10", path: []string{"IntValue"}},
+				{strValue: "true", path: []string{"BoolValue"}},
+				{strValue: "42.1", path: []string{"FloatValue"}},
+			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with nested struct value",
 			source: &struct{ Config basicAppConfig }{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
-				{strValue: "10", path: []string{"Config", "IntValue"}},
-				{strValue: "true", path: []string{"Config", "BoolValue"}},
-			},
 			env: map[string]string{
 				"CONFIG_STRING_VALUE": "FOOO",
 				"CONFIG_INT_VALUE":    "10",
 				"CONFIG_BOOL_VALUE":   "true",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "IntValue"}},
+				{strValue: "true", path: []string{"Config", "BoolValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
@@ -173,30 +173,30 @@ func TestAnalyzeStruct(t *testing.T) {
 					Config basicAppConfig
 				}
 			}{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Nested", "Config", "StringValue"}},
-				{strValue: "10", path: []string{"Nested", "Config", "IntValue"}},
-				{strValue: "true", path: []string{"Nested", "Config", "BoolValue"}},
-			},
 			env: map[string]string{
 				"NESTED_CONFIG_STRING_VALUE": "FOOO",
 				"NESTED_CONFIG_INT_VALUE":    "10",
 				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Nested", "Config", "StringValue"}},
+				{strValue: "10", path: []string{"Nested", "Config", "IntValue"}},
+				{strValue: "true", path: []string{"Nested", "Config", "BoolValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with nested struct pointer",
 			source: &struct{ Config *basicAppConfig }{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
-				{strValue: "10", path: []string{"Config", "IntValue"}},
-				{strValue: "true", path: []string{"Config", "BoolValue"}},
-			},
 			env: map[string]string{
 				"CONFIG_STRING_VALUE": "FOOO",
 				"CONFIG_INT_VALUE":    "10",
 				"CONFIG_BOOL_VALUE":   "true",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "IntValue"}},
+				{strValue: "true", path: []string{"Config", "BoolValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
@@ -207,15 +207,15 @@ func TestAnalyzeStruct(t *testing.T) {
 					Config *basicAppConfig
 				}
 			}{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Nested", "Config", "StringValue"}},
-				{strValue: "10", path: []string{"Nested", "Config", "IntValue"}},
-				{strValue: "true", path: []string{"Nested", "Config", "BoolValue"}},
-			},
 			env: map[string]string{
 				"NESTED_CONFIG_STRING_VALUE": "FOOO",
 				"NESTED_CONFIG_INT_VALUE":    "10",
 				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Nested", "Config", "StringValue"}},
+				{strValue: "10", path: []string{"Nested", "Config", "IntValue"}},
+				{strValue: "true", path: []string{"Nested", "Config", "BoolValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
@@ -226,26 +226,26 @@ func TestAnalyzeStruct(t *testing.T) {
 					Config basicAppConfig
 				}
 			}{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Nested", "Config", "StringValue"}},
-				{strValue: "10", path: []string{"Nested", "Config", "IntValue"}},
-				{strValue: "true", path: []string{"Nested", "Config", "BoolValue"}},
-			},
 			env: map[string]string{
 				"NESTED_CONFIG_STRING_VALUE": "FOOO",
 				"NESTED_CONFIG_INT_VALUE":    "10",
 				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Nested", "Config", "StringValue"}},
+				{strValue: "10", path: []string{"Nested", "Config", "IntValue"}},
+				{strValue: "true", path: []string{"Nested", "Config", "BoolValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with pointer to value",
 			source: &struct{ IntValue *int }{},
-			expected: []*envValue{
-				{strValue: "10", path: []string{"IntValue"}},
-			},
 			env: map[string]string{
 				"INT_VALUE": "10",
+			},
+			expected: []*envValue{
+				{strValue: "10", path: []string{"IntValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
@@ -256,95 +256,95 @@ func TestAnalyzeStruct(t *testing.T) {
 					IntValue *int
 				}
 			}{},
-			expected: []*envValue{
-				{strValue: "10", path: []string{"Config", "IntValue"}},
-			},
 			env: map[string]string{
 				"CONFIG_INT_VALUE": "10",
+			},
+			expected: []*envValue{
+				{strValue: "10", path: []string{"Config", "IntValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with double pointer to int value",
 			source: &struct{ Config **int }{},
-			expected: []*envValue{
-				{strValue: "10", path: []string{"Config"}},
-			},
 			env: map[string]string{
 				"CONFIG": "10",
+			},
+			expected: []*envValue{
+				{strValue: "10", path: []string{"Config"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with a double pointer to struct",
 			source: &struct{ Config **basicAppConfig }{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
-				{strValue: "10", path: []string{"Config", "IntValue"}},
-				{strValue: "true", path: []string{"Config", "BoolValue"}},
-			},
 			env: map[string]string{
 				"CONFIG_STRING_VALUE": "FOOO",
 				"CONFIG_INT_VALUE":    "10",
 				"CONFIG_BOOL_VALUE":   "true",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "IntValue"}},
+				{strValue: "true", path: []string{"Config", "BoolValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with interface delegation",
 			source: &delegatorType{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"StringValue"}},
-				{strValue: "10", path: []string{"IntValue"}},
-			},
 			env: map[string]string{
 				"STRING_VALUE": "FOOO",
 				"INT_VALUE":    "10",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"StringValue"}},
+				{strValue: "10", path: []string{"IntValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with a map[string]string",
 			source: &struct{ Config map[string]string }{},
-			expected: []*envValue{
-				{strValue: "FOO", path: []string{"Config", "foo"}},
-				{strValue: "MEH", path: []string{"Config", "bar"}},
-				{strValue: "BAR", path: []string{"Config", "biz"}},
-			},
 			env: map[string]string{
 				"CONFIG_FOO": "FOO",
 				"CONFIG_BAR": "MEH",
 				"CONFIG_BIZ": "BAR",
+			},
+			expected: []*envValue{
+				{strValue: "FOO", path: []string{"Config", "foo"}},
+				{strValue: "MEH", path: []string{"Config", "bar"}},
+				{strValue: "BAR", path: []string{"Config", "biz"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with a map[string]struct",
 			source: &struct{ Config map[string]basicAppConfig }{},
-			expected: []*envValue{
-				{strValue: "FOO", path: []string{"Config", "foo", "StringValue"}},
-				{strValue: "MEH", path: []string{"Config", "bar", "StringValue"}},
-				{strValue: "BAR", path: []string{"Config", "biz", "StringValue"}},
-			},
 			env: map[string]string{
 				"CONFIG_FOO_STRING_VALUE": "FOO",
 				"CONFIG_BAR_STRING_VALUE": "MEH",
 				"CONFIG_BIZ_STRING_VALUE": "BAR",
+			},
+			expected: []*envValue{
+				{strValue: "FOO", path: []string{"Config", "foo", "StringValue"}},
+				{strValue: "MEH", path: []string{"Config", "bar", "StringValue"}},
+				{strValue: "BAR", path: []string{"Config", "biz", "StringValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with a map[string]*struct",
 			source: &struct{ Config map[string]*basicAppConfig }{},
-			expected: []*envValue{
-				{strValue: "FOO", path: []string{"Config", "foo", "StringValue"}},
-				{strValue: "MEH", path: []string{"Config", "bar", "StringValue"}},
-				{strValue: "BAR", path: []string{"Config", "biz", "StringValue"}},
-			},
 			env: map[string]string{
 				"CONFIG_FOO_STRING_VALUE": "FOO",
 				"CONFIG_BAR_STRING_VALUE": "MEH",
 				"CONFIG_BIZ_STRING_VALUE": "BAR",
+			},
+			expected: []*envValue{
+				{strValue: "FOO", path: []string{"Config", "foo", "StringValue"}},
+				{strValue: "MEH", path: []string{"Config", "bar", "StringValue"}},
+				{strValue: "BAR", path: []string{"Config", "biz", "StringValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
@@ -353,131 +353,131 @@ func TestAnalyzeStruct(t *testing.T) {
 			source: &struct {
 				Config map[int]map[string]*basicAppConfig
 			}{},
-			expected: []*envValue{
-				{strValue: "FOO", path: []string{"Config", "0", "foo", "StringValue"}},
-				{strValue: "MEH", path: []string{"Config", "1", "bar", "StringValue"}},
-				{strValue: "BAR", path: []string{"Config", "0", "biz", "StringValue"}},
-			},
 			env: map[string]string{
 				"CONFIG_0_FOO_STRING_VALUE": "FOO",
 				"CONFIG_1_BAR_STRING_VALUE": "MEH",
 				"CONFIG_0_BIZ_STRING_VALUE": "BAR",
+			},
+			expected: []*envValue{
+				{strValue: "FOO", path: []string{"Config", "0", "foo", "StringValue"}},
+				{strValue: "MEH", path: []string{"Config", "1", "bar", "StringValue"}},
+				{strValue: "BAR", path: []string{"Config", "0", "biz", "StringValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with a slice of ints",
 			source: &struct{ Config []int }{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Config", "0"}},
-				{strValue: "10", path: []string{"Config", "1"}},
-				{strValue: "true", path: []string{"Config", "2"}},
-			},
 			env: map[string]string{
 				"CONFIG_0": "FOOO",
 				"CONFIG_1": "10",
 				"CONFIG_2": "true",
 			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0"}},
+				{strValue: "10", path: []string{"Config", "1"}},
+				{strValue: "true", path: []string{"Config", "2"}},
+			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
-			desc:     "should fail with an invalid key for a slice",
-			source:   &struct{ Config []int }{},
-			expected: []*envValue{},
+			desc:   "should fail with an invalid key for a slice",
+			source: &struct{ Config []int }{},
 			env: map[string]string{
 				"CONFIG_0":      "FOOO",
 				"CONFIG_1":      "10",
 				"CONFIG_PATATE": "true",
 			},
-			then: analyzeStructShouldFail,
+			expected: []*envValue{},
+			then:     analyzeStructShouldFail,
 		},
 		{
 			desc:   "should succeed with an array to value",
 			source: &struct{ Config [10]int }{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Config", "0"}},
-				{strValue: "10", path: []string{"Config", "1"}},
-				{strValue: "true", path: []string{"Config", "2"}},
-			},
 			env: map[string]string{
 				"CONFIG_0": "FOOO",
 				"CONFIG_1": "10",
 				"CONFIG_2": "true",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0"}},
+				{strValue: "10", path: []string{"Config", "1"}},
+				{strValue: "true", path: []string{"Config", "2"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
-			desc:     "should fail with an array and an out of bound index",
-			source:   &struct{ Config [10]int }{},
-			expected: []*envValue{},
+			desc:   "should fail with an array and an out of bound index",
+			source: &struct{ Config [10]int }{},
 			env: map[string]string{
 				"CONFIG_11": "10",
 			},
-			then: analyzeStructShouldFail,
+			expected: []*envValue{},
+			then:     analyzeStructShouldFail,
 		},
 		{
 			desc:   "should succeed with an array to value",
 			source: &struct{ Config [10]int }{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Config", "0"}},
-				{strValue: "10", path: []string{"Config", "1"}},
-				{strValue: "true", path: []string{"Config", "2"}},
-			},
 			env: map[string]string{
 				"CONFIG_0": "FOOO",
 				"CONFIG_1": "10",
 				"CONFIG_2": "true",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0"}},
+				{strValue: "10", path: []string{"Config", "1"}},
+				{strValue: "true", path: []string{"Config", "2"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with a slice of struct",
 			source: &struct{ Config []basicAppConfig }{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Config", "0", "StringValue"}},
-				{strValue: "10", path: []string{"Config", "0", "IntValue"}},
-				{strValue: "MIMI", path: []string{"Config", "1", "StringValue"}},
-				{strValue: "15", path: []string{"Config", "1", "IntValue"}},
-			},
 			env: map[string]string{
 				"CONFIG_0_STRING_VALUE": "FOOO",
 				"CONFIG_0_INT_VALUE":    "10",
 				"CONFIG_1_STRING_VALUE": "MIMI",
 				"CONFIG_1_INT_VALUE":    "15",
 			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "0", "IntValue"}},
+				{strValue: "MIMI", path: []string{"Config", "1", "StringValue"}},
+				{strValue: "15", path: []string{"Config", "1", "IntValue"}},
+			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with a [][]struct",
 			source: &struct{ Config [][]basicAppConfig }{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Config", "0", "0", "StringValue"}},
-				{strValue: "10", path: []string{"Config", "0", "0", "IntValue"}},
-				{strValue: "MIMI", path: []string{"Config", "1", "1", "StringValue"}},
-				{strValue: "15", path: []string{"Config", "1", "1", "IntValue"}},
-			},
 			env: map[string]string{
 				"CONFIG_0_0_STRING_VALUE": "FOOO",
 				"CONFIG_0_0_INT_VALUE":    "10",
 				"CONFIG_1_1_STRING_VALUE": "MIMI",
 				"CONFIG_1_1_INT_VALUE":    "15",
 			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0", "0", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "0", "0", "IntValue"}},
+				{strValue: "MIMI", path: []string{"Config", "1", "1", "StringValue"}},
+				{strValue: "15", path: []string{"Config", "1", "1", "IntValue"}},
+			},
 			then: analyzeStructShouldSucceed,
 		},
 		{
 			desc:   "should succeed with a []map[string]struct",
 			source: &struct{ Config []map[string]basicAppConfig }{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Config", "0", "foo", "StringValue"}},
-				{strValue: "10", path: []string{"Config", "0", "foo", "IntValue"}},
-				{strValue: "MIMI", path: []string{"Config", "1", "bar", "StringValue"}},
-				{strValue: "15", path: []string{"Config", "1", "bar", "IntValue"}},
-			},
 			env: map[string]string{
 				"CONFIG_0_FOO_STRING_VALUE": "FOOO",
 				"CONFIG_0_FOO_INT_VALUE":    "10",
 				"CONFIG_1_BAR_STRING_VALUE": "MIMI",
 				"CONFIG_1_BAR_INT_VALUE":    "15",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0", "foo", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "0", "foo", "IntValue"}},
+				{strValue: "MIMI", path: []string{"Config", "1", "bar", "StringValue"}},
+				{strValue: "15", path: []string{"Config", "1", "bar", "IntValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
@@ -487,15 +487,15 @@ func TestAnalyzeStruct(t *testing.T) {
 				Config basicAppConfig
 				Time   func() time.Time
 			}{},
-			expected: []*envValue{
-				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
-				{strValue: "10", path: []string{"Config", "IntValue"}},
-				{strValue: "true", path: []string{"Config", "BoolValue"}},
-			},
 			env: map[string]string{
 				"CONFIG_STRING_VALUE": "FOOO",
 				"CONFIG_INT_VALUE":    "10",
 				"CONFIG_BOOL_VALUE":   "true",
+			},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "IntValue"}},
+				{strValue: "true", path: []string{"Config", "BoolValue"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
@@ -505,15 +505,15 @@ func TestAnalyzeStruct(t *testing.T) {
 				Basic     *Basic
 				UsersFile string
 			}{},
-			expected: []*envValue{
-				{strValue: "UserZero", path: []string{"Basic", "0"}},
-				{strValue: "UserOne", path: []string{"Basic", "1"}},
-				{strValue: "path/to/file", path: []string{"UsersFile"}},
-			},
 			env: map[string]string{
 				"BASIC_0":    "UserZero",
 				"BASIC_1":    "UserOne",
 				"USERS_FILE": "path/to/file",
+			},
+			expected: []*envValue{
+				{strValue: "UserZero", path: []string{"Basic", "0"}},
+				{strValue: "UserOne", path: []string{"Basic", "1"}},
+				{strValue: "path/to/file", path: []string{"UsersFile"}},
 			},
 			then: analyzeStructShouldSucceed,
 		},
@@ -532,32 +532,32 @@ func TestAnalyzeStruct(t *testing.T) {
 
 func TestEnvVarFromPath(t *testing.T) {
 	testCases := []struct {
-		desc        string
-		prefix      string
-		separator   string
-		paths       []string
-		expectation string
+		desc      string
+		prefix    string
+		separator string
+		paths     []string
+		expected  string
 	}{
 		{
-			desc:        "BlankPrefix",
-			prefix:      "",
-			separator:   "_",
-			paths:       []string{"Foo"},
-			expectation: "FOO",
+			desc:      "BlankPrefix",
+			prefix:    "",
+			separator: "_",
+			paths:     []string{"Foo"},
+			expected:  "FOO",
 		},
 		{
-			desc:        "NonBlankPrefix",
-			prefix:      "YOUPI",
-			separator:   "_",
-			paths:       []string{"Foo"},
-			expectation: "YOUPI_FOO",
+			desc:      "NonBlankPrefix",
+			prefix:    "YOUPI",
+			separator: "_",
+			paths:     []string{"Foo"},
+			expected:  "YOUPI_FOO",
 		},
 		{
-			desc:        "CamelCasedPathMembers",
-			prefix:      "YOUPI",
-			separator:   "_",
-			paths:       []string{"Foo", "IamGroot", "IAmBatman"},
-			expectation: "YOUPI_FOO_IAM_GROOT_I_AM_BATMAN",
+			desc:      "CamelCasedPathMembers",
+			prefix:    "YOUPI",
+			separator: "_",
+			paths:     []string{"Foo", "IamGroot", "IAmBatman"},
+			expected:  "YOUPI_FOO_IAM_GROOT_I_AM_BATMAN",
 		},
 	}
 
@@ -569,7 +569,7 @@ func TestEnvVarFromPath(t *testing.T) {
 			subject := NewEnvSource(test.prefix, test.separator, map[reflect.Type]parse.Parser{})
 
 			result := subject.envVarFromPath(test.paths)
-			assert.Exactly(t, test.expectation, result)
+			assert.Exactly(t, test.expected, result)
 		})
 	}
 }
@@ -580,18 +580,18 @@ func TestAnalyzeAndAssignFlowWithArrayConfig(t *testing.T) {
 	}{}
 
 	test := struct {
-		source      interface{}
-		expectation []*envValue
-		env         map[string]string
+		source   interface{}
+		env      map[string]string
+		expected []*envValue
 	}{
 		source: &sourceConfig,
-		expectation: []*envValue{
-			{strValue: "one", path: []string{"StringArray", "0"}},
-			{strValue: "two", path: []string{"StringArray", "1"}},
-		},
 		env: map[string]string{
 			"STRING_ARRAY_0": "one",
 			"STRING_ARRAY_1": "two",
+		},
+		expected: []*envValue{
+			{strValue: "one", path: []string{"StringArray", "0"}},
+			{strValue: "two", path: []string{"StringArray", "1"}},
 		},
 	}
 

--- a/envsource_analyzestruct_test.go
+++ b/envsource_analyzestruct_test.go
@@ -1,0 +1,763 @@
+package staert
+
+import (
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/containous/flaeg/parse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type basicAppConfig struct {
+	StringValue string
+	IntValue    int
+	BoolValue   bool
+}
+
+type typeInterface interface {
+	Foo() string
+}
+
+type delegatorType struct {
+	typeInterface
+	IntValue    int
+	StringValue string
+}
+
+type sortableEnvValues []*envValue
+
+func (s sortableEnvValues) Len() int {
+	return len(s)
+}
+
+func (s sortableEnvValues) Less(i, j int) bool {
+	return s[i].strValue < s[j].strValue
+}
+
+func (s sortableEnvValues) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Users authentication users
+type Users []string
+
+type Basic struct {
+	Users     `mapstructure:","`
+	UsersFile string
+}
+
+func setupEnv(t *testing.T, env map[string]string) {
+	t.Helper()
+
+	for k, v := range env {
+		err := os.Setenv(k, v)
+		require.NoError(t, err)
+	}
+}
+
+func cleanupEnv(t *testing.T, env map[string]string) {
+	t.Helper()
+
+	for k := range env {
+		err := os.Unsetenv(k)
+		require.NoError(t, err)
+	}
+}
+
+func analyzeStructShouldSucceed(t *testing.T, expectation, result sortableEnvValues, err error) {
+	t.Helper()
+
+	require.NoError(t, err)
+	assert.Lenf(t, result, len(expectation), "Unexpected count of values returned")
+
+	// Sort by value, according to strValue (which might not be the best
+	// idea ever), in order to ensure index based comparison consistency
+	sort.Sort(expectation)
+	sort.Sort(result)
+
+	for i, v := range expectation {
+		assert.Equal(t, v.strValue, result[i].strValue)
+		assert.Exactly(t, v.path, result[i].path)
+	}
+}
+
+func analyzeStructShouldFail(t *testing.T, expectation, result sortableEnvValues, err error) {
+	t.Helper()
+
+	require.Error(t, err)
+}
+
+func TestAnalyzeStruct(t *testing.T) {
+	subject := NewEnvSource("", "_", map[reflect.Type]parse.Parser{})
+
+	testCases := []struct {
+		desc     string
+		source   interface{}
+		expected []*envValue
+		env      map[string]string
+		then     func(t *testing.T, expectation, result sortableEnvValues, err error)
+	}{
+		{
+			desc:   "should succeed with basic struct",
+			source: &basicAppConfig{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"StringValue"}},
+				{strValue: "10", path: []string{"IntValue"}},
+				{strValue: "true", path: []string{"BoolValue"}},
+			},
+			env: map[string]string{
+				"STRING_VALUE": "FOOO",
+				"INT_VALUE":    "10",
+				"BOOL_VALUE":   "true",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc: "should succeed with unexported fields",
+			source: &struct {
+				unexported string
+				IntValue   int
+			}{},
+			expected: []*envValue{
+				{strValue: "10", path: []string{"IntValue"}},
+			},
+			env: map[string]string{
+				"UNEXPORTED": "FOOO",
+				"INT_VALUE":  "10",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc: "should succeed with embedded struct",
+			source: &struct {
+				basicAppConfig
+				FloatValue float32
+			}{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"StringValue"}},
+				{strValue: "10", path: []string{"IntValue"}},
+				{strValue: "true", path: []string{"BoolValue"}},
+				{strValue: "42.1", path: []string{"FloatValue"}},
+			},
+			env: map[string]string{
+				"STRING_VALUE": "FOOO",
+				"INT_VALUE":    "10",
+				"BOOL_VALUE":   "true",
+				"FLOAT_VALUE":  "42.1",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with nested struct value",
+			source: &struct{ Config basicAppConfig }{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "IntValue"}},
+				{strValue: "true", path: []string{"Config", "BoolValue"}},
+			},
+			env: map[string]string{
+				"CONFIG_STRING_VALUE": "FOOO",
+				"CONFIG_INT_VALUE":    "10",
+				"CONFIG_BOOL_VALUE":   "true",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc: "should succeed with double nested struct value",
+			source: &struct {
+				Nested struct {
+					Config basicAppConfig
+				}
+			}{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Nested", "Config", "StringValue"}},
+				{strValue: "10", path: []string{"Nested", "Config", "IntValue"}},
+				{strValue: "true", path: []string{"Nested", "Config", "BoolValue"}},
+			},
+			env: map[string]string{
+				"NESTED_CONFIG_STRING_VALUE": "FOOO",
+				"NESTED_CONFIG_INT_VALUE":    "10",
+				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with nested struct pointer",
+			source: &struct{ Config *basicAppConfig }{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "IntValue"}},
+				{strValue: "true", path: []string{"Config", "BoolValue"}},
+			},
+			env: map[string]string{
+				"CONFIG_STRING_VALUE": "FOOO",
+				"CONFIG_INT_VALUE":    "10",
+				"CONFIG_BOOL_VALUE":   "true",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc: "should succeed with double nested struct pointer",
+			source: &struct {
+				Nested *struct {
+					Config *basicAppConfig
+				}
+			}{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Nested", "Config", "StringValue"}},
+				{strValue: "10", path: []string{"Nested", "Config", "IntValue"}},
+				{strValue: "true", path: []string{"Nested", "Config", "BoolValue"}},
+			},
+			env: map[string]string{
+				"NESTED_CONFIG_STRING_VALUE": "FOOO",
+				"NESTED_CONFIG_INT_VALUE":    "10",
+				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc: "should succeed with nested struct pointer to struct",
+			source: &struct {
+				Nested *struct {
+					Config basicAppConfig
+				}
+			}{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Nested", "Config", "StringValue"}},
+				{strValue: "10", path: []string{"Nested", "Config", "IntValue"}},
+				{strValue: "true", path: []string{"Nested", "Config", "BoolValue"}},
+			},
+			env: map[string]string{
+				"NESTED_CONFIG_STRING_VALUE": "FOOO",
+				"NESTED_CONFIG_INT_VALUE":    "10",
+				"NESTED_CONFIG_BOOL_VALUE":   "true",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with pointer to value",
+			source: &struct{ IntValue *int }{},
+			expected: []*envValue{
+				{strValue: "10", path: []string{"IntValue"}},
+			},
+			env: map[string]string{
+				"INT_VALUE": "10",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc: "should succeed with nested pointer to value",
+			source: &struct {
+				Config struct {
+					IntValue *int
+				}
+			}{},
+			expected: []*envValue{
+				{strValue: "10", path: []string{"Config", "IntValue"}},
+			},
+			env: map[string]string{
+				"CONFIG_INT_VALUE": "10",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with double pointer to int value",
+			source: &struct{ Config **int }{},
+			expected: []*envValue{
+				{strValue: "10", path: []string{"Config"}},
+			},
+			env: map[string]string{
+				"CONFIG": "10",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with a double pointer to struct",
+			source: &struct{ Config **basicAppConfig }{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "IntValue"}},
+				{strValue: "true", path: []string{"Config", "BoolValue"}},
+			},
+			env: map[string]string{
+				"CONFIG_STRING_VALUE": "FOOO",
+				"CONFIG_INT_VALUE":    "10",
+				"CONFIG_BOOL_VALUE":   "true",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with interface delegation",
+			source: &delegatorType{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"StringValue"}},
+				{strValue: "10", path: []string{"IntValue"}},
+			},
+			env: map[string]string{
+				"STRING_VALUE": "FOOO",
+				"INT_VALUE":    "10",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with a map[string]string",
+			source: &struct{ Config map[string]string }{},
+			expected: []*envValue{
+				{strValue: "FOO", path: []string{"Config", "foo"}},
+				{strValue: "MEH", path: []string{"Config", "bar"}},
+				{strValue: "BAR", path: []string{"Config", "biz"}},
+			},
+			env: map[string]string{
+				"CONFIG_FOO": "FOO",
+				"CONFIG_BAR": "MEH",
+				"CONFIG_BIZ": "BAR",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with a map[string]struct",
+			source: &struct{ Config map[string]basicAppConfig }{},
+			expected: []*envValue{
+				{strValue: "FOO", path: []string{"Config", "foo", "StringValue"}},
+				{strValue: "MEH", path: []string{"Config", "bar", "StringValue"}},
+				{strValue: "BAR", path: []string{"Config", "biz", "StringValue"}},
+			},
+			env: map[string]string{
+				"CONFIG_FOO_STRING_VALUE": "FOO",
+				"CONFIG_BAR_STRING_VALUE": "MEH",
+				"CONFIG_BIZ_STRING_VALUE": "BAR",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with a map[string]*struct",
+			source: &struct{ Config map[string]*basicAppConfig }{},
+			expected: []*envValue{
+				{strValue: "FOO", path: []string{"Config", "foo", "StringValue"}},
+				{strValue: "MEH", path: []string{"Config", "bar", "StringValue"}},
+				{strValue: "BAR", path: []string{"Config", "biz", "StringValue"}},
+			},
+			env: map[string]string{
+				"CONFIG_FOO_STRING_VALUE": "FOO",
+				"CONFIG_BAR_STRING_VALUE": "MEH",
+				"CONFIG_BIZ_STRING_VALUE": "BAR",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc: "should succeed with a map of map",
+			source: &struct {
+				Config map[int]map[string]*basicAppConfig
+			}{},
+			expected: []*envValue{
+				{strValue: "FOO", path: []string{"Config", "0", "foo", "StringValue"}},
+				{strValue: "MEH", path: []string{"Config", "1", "bar", "StringValue"}},
+				{strValue: "BAR", path: []string{"Config", "0", "biz", "StringValue"}},
+			},
+			env: map[string]string{
+				"CONFIG_0_FOO_STRING_VALUE": "FOO",
+				"CONFIG_1_BAR_STRING_VALUE": "MEH",
+				"CONFIG_0_BIZ_STRING_VALUE": "BAR",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with a slice of ints",
+			source: &struct{ Config []int }{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0"}},
+				{strValue: "10", path: []string{"Config", "1"}},
+				{strValue: "true", path: []string{"Config", "2"}},
+			},
+			env: map[string]string{
+				"CONFIG_0": "FOOO",
+				"CONFIG_1": "10",
+				"CONFIG_2": "true",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:     "should fail with an invalid key for a slice",
+			source:   &struct{ Config []int }{},
+			expected: []*envValue{},
+			env: map[string]string{
+				"CONFIG_0":      "FOOO",
+				"CONFIG_1":      "10",
+				"CONFIG_PATATE": "true",
+			},
+			then: analyzeStructShouldFail,
+		},
+		{
+			desc:   "should succeed with an array to value",
+			source: &struct{ Config [10]int }{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0"}},
+				{strValue: "10", path: []string{"Config", "1"}},
+				{strValue: "true", path: []string{"Config", "2"}},
+			},
+			env: map[string]string{
+				"CONFIG_0": "FOOO",
+				"CONFIG_1": "10",
+				"CONFIG_2": "true",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:     "should fail with an array and an out of bound index",
+			source:   &struct{ Config [10]int }{},
+			expected: []*envValue{},
+			env: map[string]string{
+				"CONFIG_11": "10",
+			},
+			then: analyzeStructShouldFail,
+		},
+		{
+			desc:   "should succeed with an array to value",
+			source: &struct{ Config [10]int }{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0"}},
+				{strValue: "10", path: []string{"Config", "1"}},
+				{strValue: "true", path: []string{"Config", "2"}},
+			},
+			env: map[string]string{
+				"CONFIG_0": "FOOO",
+				"CONFIG_1": "10",
+				"CONFIG_2": "true",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with a slice of struct",
+			source: &struct{ Config []basicAppConfig }{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "0", "IntValue"}},
+				{strValue: "MIMI", path: []string{"Config", "1", "StringValue"}},
+				{strValue: "15", path: []string{"Config", "1", "IntValue"}},
+			},
+			env: map[string]string{
+				"CONFIG_0_STRING_VALUE": "FOOO",
+				"CONFIG_0_INT_VALUE":    "10",
+				"CONFIG_1_STRING_VALUE": "MIMI",
+				"CONFIG_1_INT_VALUE":    "15",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with a [][]struct",
+			source: &struct{ Config [][]basicAppConfig }{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0", "0", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "0", "0", "IntValue"}},
+				{strValue: "MIMI", path: []string{"Config", "1", "1", "StringValue"}},
+				{strValue: "15", path: []string{"Config", "1", "1", "IntValue"}},
+			},
+			env: map[string]string{
+				"CONFIG_0_0_STRING_VALUE": "FOOO",
+				"CONFIG_0_0_INT_VALUE":    "10",
+				"CONFIG_1_1_STRING_VALUE": "MIMI",
+				"CONFIG_1_1_INT_VALUE":    "15",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc:   "should succeed with a []map[string]struct",
+			source: &struct{ Config []map[string]basicAppConfig }{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0", "foo", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "0", "foo", "IntValue"}},
+				{strValue: "MIMI", path: []string{"Config", "1", "bar", "StringValue"}},
+				{strValue: "15", path: []string{"Config", "1", "bar", "IntValue"}},
+			},
+			env: map[string]string{
+				"CONFIG_0_FOO_STRING_VALUE": "FOOO",
+				"CONFIG_0_FOO_INT_VALUE":    "10",
+				"CONFIG_1_BAR_STRING_VALUE": "MIMI",
+				"CONFIG_1_BAR_INT_VALUE":    "15",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc: "should succeed when config has exported fields that are of type func",
+			source: &struct {
+				Config basicAppConfig
+				Time   func() time.Time
+			}{},
+			expected: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "IntValue"}},
+				{strValue: "true", path: []string{"Config", "BoolValue"}},
+			},
+			env: map[string]string{
+				"CONFIG_STRING_VALUE": "FOOO",
+				"CONFIG_INT_VALUE":    "10",
+				"CONFIG_BOOL_VALUE":   "true",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+		{
+			desc: "should succeed with an type alias to an array",
+			source: &struct {
+				Basic     *Basic
+				UsersFile string
+			}{},
+			expected: []*envValue{
+				{strValue: "UserZero", path: []string{"Basic", "0"}},
+				{strValue: "UserOne", path: []string{"Basic", "1"}},
+				{strValue: "path/to/file", path: []string{"UsersFile"}},
+			},
+			env: map[string]string{
+				"BASIC_0":    "UserZero",
+				"BASIC_1":    "UserOne",
+				"USERS_FILE": "path/to/file",
+			},
+			then: analyzeStructShouldSucceed,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			setupEnv(t, test.env)
+			defer cleanupEnv(t, test.env)
+
+			res, err := subject.analyzeStruct(reflect.TypeOf(test.source).Elem(), nil)
+			test.then(t, test.expected, res, err)
+		})
+	}
+}
+
+func TestEnvVarFromPath(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		prefix      string
+		separator   string
+		paths       []string
+		expectation string
+	}{
+		{
+			desc:        "BlankPrefix",
+			prefix:      "",
+			separator:   "_",
+			paths:       []string{"Foo"},
+			expectation: "FOO",
+		},
+		{
+			desc:        "NonBlankPrefix",
+			prefix:      "YOUPI",
+			separator:   "_",
+			paths:       []string{"Foo"},
+			expectation: "YOUPI_FOO",
+		},
+		{
+			desc:        "CamelCasedPathMembers",
+			prefix:      "YOUPI",
+			separator:   "_",
+			paths:       []string{"Foo", "IamGroot", "IAmBatman"},
+			expectation: "YOUPI_FOO_IAM_GROOT_I_AM_BATMAN",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			subject := NewEnvSource(test.prefix, test.separator, map[reflect.Type]parse.Parser{})
+
+			result := subject.envVarFromPath(test.paths)
+			assert.Exactly(t, test.expectation, result)
+		})
+	}
+}
+
+func TestAnalyzeAndAssignFlowWithArrayConfig(t *testing.T) {
+	sourceConfig := struct {
+		StringArray []string
+	}{}
+
+	test := struct {
+		source      interface{}
+		expectation []*envValue
+		env         map[string]string
+	}{
+		source: &sourceConfig,
+		expectation: []*envValue{
+			{strValue: "one", path: []string{"StringArray", "0"}},
+			{strValue: "two", path: []string{"StringArray", "1"}},
+		},
+		env: map[string]string{
+			"STRING_ARRAY_0": "one",
+			"STRING_ARRAY_1": "two",
+		},
+	}
+
+	setupEnv(t, test.env)
+	defer cleanupEnv(t, test.env)
+
+	parsers, err := parse.LoadParsers(nil)
+	require.NoError(t, err)
+
+	subject := NewEnvSource("", "_", parsers)
+
+	res, err := subject.analyzeStruct(reflect.TypeOf(test.source).Elem(), nil)
+	require.NoError(t, err)
+
+	err = subject.assignValues(reflect.ValueOf(&sourceConfig), res, nil)
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []string{"one", "two"}, sourceConfig.StringArray)
+}
+
+func TestNextLevelKeys(t *testing.T) {
+	subject := NewEnvSource("", "_", map[reflect.Type]parse.Parser{})
+
+	testCases := []struct {
+		desc     string
+		prefix   string
+		env      []string
+		expected []string
+	}{
+		{
+			desc:   "should strip the key part from the env name",
+			prefix: "CONFIG_APP",
+			env: []string{
+				"CONFIG_APP_BATMAN_FOO",
+				"CONFIG_APP_ROBIN_FOO",
+				"CONFIG_APP_JOCKER_FOO",
+			},
+			expected: []string{
+				"CONFIG_APP_BATMAN",
+				"CONFIG_APP_ROBIN",
+				"CONFIG_APP_JOCKER",
+			},
+		},
+		{
+			desc:   "should handle multiple equal keys",
+			prefix: "CONFIG_APP",
+			env: []string{
+				"CONFIG_APP_BATMAN_FOO",
+				"CONFIG_APP_ROBIN_FOO",
+				"CONFIG_APP_JOCKER_FOO",
+				"CONFIG_APP_BATMAN_BAR",
+			},
+			expected: []string{
+				"CONFIG_APP_BATMAN",
+				"CONFIG_APP_ROBIN",
+				"CONFIG_APP_JOCKER",
+				"CONFIG_APP_BATMAN",
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			res := subject.nextLevelKeys(test.prefix, test.env)
+			assert.ElementsMatch(t, test.expected, res)
+		})
+	}
+}
+
+func TestEnvVarsWithPrefix(t *testing.T) {
+	subject := NewEnvSource("", "_", map[reflect.Type]parse.Parser{})
+
+	testCases := []struct {
+		desc     string
+		prefix   string
+		env      map[string]string
+		expected []string
+	}{
+		{
+			desc:   "should filter out values that dont start with the prefix",
+			prefix: "STAERT_APP",
+			env: map[string]string{
+				"STRING_VALUE":          "FOOO",
+				"INT_VALUE":             "10",
+				"BOOL_VALUE":            "true",
+				"STAERT_APP_BOOL_VALUE": "true",
+				"STAERT_APP_BAR_VALUE":  "true",
+			},
+			expected: []string{"STAERT_APP_BAR_VALUE", "STAERT_APP_BOOL_VALUE"},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			setupEnv(t, test.env)
+			defer cleanupEnv(t, test.env)
+
+			res := subject.envVarsWithPrefix(test.prefix)
+			assert.ElementsMatch(t, test.expected, res)
+		})
+	}
+}
+
+func TestUnique(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		in       []string
+		expected []string
+	}{
+		{
+			desc:     "WithDuplicates",
+			in:       []string{"FOO", "BAR", "BIZ", "FOO", "BIZ"},
+			expected: []string{"FOO", "BAR", "BIZ"},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			res := unique(test.in)
+			assert.ElementsMatch(t, test.expected, res)
+		})
+	}
+}
+
+func TestKeyFromEnvVar(t *testing.T) {
+	subject := NewEnvSource("", "_", map[reflect.Type]parse.Parser{})
+
+	testCases := []struct {
+		desc     string
+		prefix   string
+		envVar   string
+		expected string
+	}{
+		{
+			desc:     "WithPrefix",
+			prefix:   "CONFIG_APP",
+			envVar:   "CONFIG_APP_BATMAN",
+			expected: "batman",
+		},
+		{
+			desc:     "WithPrefixAndSuffix",
+			prefix:   "CONFIG_APP",
+			envVar:   "CONFIG_APP_BATMAN_FOO",
+			expected: "batman",
+		},
+		{
+			desc:     "WithoutPrefix",
+			prefix:   "",
+			envVar:   "BATMAN",
+			expected: "batman",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			res := subject.keyFromEnvVar(test.envVar, test.prefix)
+			assert.Equal(t, test.expected, res)
+		})
+	}
+}

--- a/envsource_assign_test.go
+++ b/envsource_assign_test.go
@@ -1,0 +1,353 @@
+package staert
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/containous/flaeg/parse"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getPtrPtrConfig() *struct {
+	StringValue string
+	NextPointer **basicAppConfig
+} {
+	configPtr := &basicAppConfig{
+		BoolValue:   true,
+		IntValue:    1,
+		StringValue: "string",
+	}
+	expectedPtrPtr := &struct {
+		StringValue string
+		NextPointer **basicAppConfig
+	}{
+		StringValue: "FOO",
+	}
+	expectedPtrPtr.NextPointer = &configPtr
+	return expectedPtrPtr
+}
+
+func TestFilterEnvVarWithPrefix(t *testing.T) {
+	envSource := []*envValue{
+		{strValue: "FOOO", path: []string{"Config", "0", "foo", "StringValue"}},
+		{strValue: "10", path: []string{"Config", "0", "foo", "IntValue"}},
+		{strValue: "10", path: []string{"Config", "IntValue"}},
+		{strValue: "10", path: []string{"Config", "0", "0", "IntValue"}},
+	}
+
+	result := filterEnvVarWithPrefix(envSource, []string{"Config", "0", "foo"})
+
+	expected := []*envValue{
+		{strValue: "FOOO", path: []string{"StringValue"}},
+		{strValue: "10", path: []string{"IntValue"}},
+	}
+
+	assert.Exactly(t, expected, result)
+}
+
+func TestAssignValues(t *testing.T) {
+	parsers, _ := parse.LoadParsers(nil)
+	subject := &EnvSource{prefix: "", separator: "_", parsers: parsers}
+
+	testCases := []struct {
+		desc     string
+		source   interface{}
+		values   []*envValue
+		expected interface{}
+	}{
+		{
+			desc: "with a simple struct",
+			source: &struct {
+				StringValue      string
+				OtherStringValue string
+			}{},
+			values: []*envValue{
+				{strValue: "FOO", path: []string{"StringValue"}},
+				{strValue: "BAR", path: []string{"OtherStringValue"}},
+			},
+			expected: &struct {
+				StringValue      string
+				OtherStringValue string
+			}{"FOO", "BAR"},
+		},
+		{
+			desc: "when it needs an int parser",
+			source: &struct {
+				StringValue string
+				IntValue    int
+			}{},
+			values: []*envValue{
+				{strValue: "FOO", path: []string{"StringValue"}},
+				{strValue: "1", path: []string{"IntValue"}},
+			},
+			expected: &struct {
+				StringValue string
+				IntValue    int
+			}{"FOO", 1},
+		},
+		{
+			desc: "with an embedded struct",
+			source: &struct {
+				StringValue string
+				Next        basicAppConfig
+			}{},
+			values: []*envValue{
+				{strValue: "FOO", path: []string{"StringValue"}},
+				{strValue: "1", path: []string{"Next", "IntValue"}},
+				{strValue: "true", path: []string{"Next", "BoolValue"}},
+				{strValue: "string", path: []string{"Next", "StringValue"}},
+			},
+			expected: &struct {
+				StringValue string
+				Next        basicAppConfig
+			}{"FOO", basicAppConfig{
+				BoolValue:   true,
+				IntValue:    1,
+				StringValue: "string",
+			}},
+		},
+		{
+			desc: "with a pointer to a struct",
+			source: &struct {
+				StringValue string
+				NextPointer *basicAppConfig
+			}{},
+			values: []*envValue{
+				{strValue: "FOO", path: []string{"StringValue"}},
+				{strValue: "1", path: []string{"NextPointer", "IntValue"}},
+				{strValue: "true", path: []string{"NextPointer", "BoolValue"}},
+				{strValue: "string", path: []string{"NextPointer", "StringValue"}},
+			},
+			expected: &struct {
+				StringValue string
+				NextPointer *basicAppConfig
+			}{"FOO", &basicAppConfig{
+				BoolValue:   true,
+				IntValue:    1,
+				StringValue: "string",
+			}},
+		},
+		{
+			desc: "with a pointer to pointer struct",
+			source: &struct {
+				StringValue string
+				NextPointer **basicAppConfig
+			}{},
+			values: []*envValue{
+				{strValue: "FOO", path: []string{"StringValue"}},
+				{strValue: "1", path: []string{"NextPointer", "IntValue"}},
+				{strValue: "true", path: []string{"NextPointer", "BoolValue"}},
+				{strValue: "string", path: []string{"NextPointer", "StringValue"}},
+			},
+			expected: getPtrPtrConfig(),
+		},
+		{
+			desc:   "when the environment values contain a wrong path",
+			source: &delegatorType{},
+			values: []*envValue{
+				{strValue: "FOO", path: []string{"WrongPath"}},
+			},
+			expected: &delegatorType{},
+		},
+		{
+			desc:   "with interface delegation",
+			source: &delegatorType{},
+			values: []*envValue{
+				{strValue: "FOO", path: []string{"StringValue"}},
+				{strValue: "1", path: []string{"IntValue"}},
+			},
+			expected: &delegatorType{
+				IntValue:    1,
+				StringValue: "FOO",
+			},
+		},
+		{
+			desc: "with a map[string]string",
+			source: &struct {
+				Config map[string]string
+			}{},
+			values: []*envValue{
+				{strValue: "FOO", path: []string{"Config", "foo"}},
+				{strValue: "MEH", path: []string{"Config", "bar"}},
+				{strValue: "BAR", path: []string{"Config", "biz"}},
+			},
+			expected: &struct {
+				Config map[string]string
+			}{
+				Config: map[string]string{
+					"foo": "FOO",
+					"bar": "MEH",
+					"biz": "BAR",
+				},
+			},
+		},
+		{
+			desc: "with a map that uses a parser for values",
+			source: &struct {
+				Config map[string]int
+			}{},
+			values: []*envValue{
+				{strValue: "1", path: []string{"Config", "foo"}},
+				{strValue: "2", path: []string{"Config", "bar"}},
+				{strValue: "3", path: []string{"Config", "biz"}},
+			},
+			expected: &struct {
+				Config map[string]int
+			}{
+				Config: map[string]int{
+					"foo": 1,
+					"bar": 2,
+					"biz": 3,
+				},
+			},
+		},
+		{
+			desc: "with a map that needs a parser for keys",
+			source: &struct {
+				Config map[int]int
+			}{},
+			values: []*envValue{
+				{strValue: "1", path: []string{"Config", "1"}},
+				{strValue: "2", path: []string{"Config", "2"}},
+				{strValue: "3", path: []string{"Config", "3"}},
+			},
+			expected: &struct {
+				Config map[int]int
+			}{
+				Config: map[int]int{
+					1: 1,
+					2: 2,
+					3: 3,
+				},
+			},
+		},
+		{
+			desc: "with a map[string]struct",
+			source: &struct {
+				Config map[string]basicAppConfig
+			}{},
+			values: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "foo", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "foo", "IntValue"}},
+			},
+			expected: &struct {
+				Config map[string]basicAppConfig
+			}{
+				Config: map[string]basicAppConfig{
+					"foo": {
+						StringValue: "FOOO",
+						IntValue:    10,
+					},
+				},
+			},
+		},
+		{
+			desc: "with a map[int]struct",
+			source: &struct {
+				Config map[int]basicAppConfig
+			}{},
+			values: []*envValue{
+				{strValue: "FOOO", path: []string{"Config", "0", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "0", "IntValue"}},
+			},
+			expected: &struct {
+				Config map[int]basicAppConfig
+			}{
+				Config: map[int]basicAppConfig{
+					0: {
+						StringValue: "FOOO",
+						IntValue:    10,
+					},
+				},
+			},
+		},
+		{
+			desc: "with an array of int",
+			source: &struct {
+				Config []int
+			}{},
+			values: []*envValue{
+				{strValue: "1", path: []string{"Config", "0"}},
+				{strValue: "10", path: []string{"Config", "1"}},
+			},
+			expected: &struct {
+				Config []int
+			}{
+				Config: []int{1, 10},
+			},
+		},
+		{
+			desc: "with an array of struct",
+			source: &struct {
+				Config []basicAppConfig
+			}{},
+			values: []*envValue{
+				{strValue: "Test", path: []string{"Config", "0", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "0", "IntValue"}},
+				{strValue: "true", path: []string{"Config", "0", "BoolValue"}},
+				{strValue: "Test2", path: []string{"Config", "1", "StringValue"}},
+				{strValue: "20", path: []string{"Config", "1", "IntValue"}},
+				{strValue: "false", path: []string{"Config", "1", "BoolValue"}},
+			},
+			expected: &struct {
+				Config []basicAppConfig
+			}{
+				Config: []basicAppConfig{
+					{
+						BoolValue:   true,
+						IntValue:    10,
+						StringValue: "Test",
+					},
+					{
+						BoolValue:   false,
+						IntValue:    20,
+						StringValue: "Test2",
+					},
+				},
+			},
+		},
+		{
+			desc: "with an array of pointer to struct",
+			source: &struct {
+				Config []*basicAppConfig
+			}{},
+			values: []*envValue{
+				{strValue: "Test", path: []string{"Config", "0", "StringValue"}},
+				{strValue: "10", path: []string{"Config", "0", "IntValue"}},
+				{strValue: "true", path: []string{"Config", "0", "BoolValue"}},
+				{strValue: "Test2", path: []string{"Config", "1", "StringValue"}},
+				{strValue: "20", path: []string{"Config", "1", "IntValue"}},
+				{strValue: "false", path: []string{"Config", "1", "BoolValue"}},
+			},
+			expected: &struct {
+				Config []*basicAppConfig
+			}{
+				Config: []*basicAppConfig{
+					{
+						BoolValue:   true,
+						IntValue:    10,
+						StringValue: "Test",
+					},
+					{
+						BoolValue:   false,
+						IntValue:    20,
+						StringValue: "Test2",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run("should assign values to config "+test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			err := subject.assignValues(reflect.ValueOf(test.source).Elem(), test.values, []string{})
+			require.NoError(t, err)
+
+			assert.Exactly(t, test.expected, test.source)
+		})
+	}
+}


### PR DESCRIPTION
# Description

This is a first shot at providing an environment variable source to staert (and traefik). I revived #30, extended it, and finished it. I'll add documentation (it's pretty much similar to the initial PR one, so see : 
I tested it briefly with traefik, I'll send a PR there too as I get closer to a releasable state.)
I have integrated it in traefik to test, and it manages to parse the entire config tree from traefik. that covers many cases. I'm not certain it manages to SET all values though. so more tests will be needed there.

Quite some work left to do though before calling it done :

- [ ] Make sure the priority order is ok when running envsource + toml + cli
- [ ] Handle defaultPointerConfig
- [ ] Handle some edge cases
- [ ] Log correctly (info/debug..)
- [x] Document it. (see https://github.com/containous/staert/pull/30/commits/9b6531c044be53a4af22ae7b88492fa9ada5e468)
- [ ] Cleanup
- [ ] Refactor (not pretty code to my standards, but it's a good start)
- [ ] Make the env variables discoverable (list all env variable name for a given config struct, maybe separate PR)
- [ ] Bonus: Rewrite it, it's not efficient, there are better ways to do it :smile:

### DefaultPointerConfig
When it comes to `defaultPointerConfig`, some notes that made me understand it 🥇 
- it's used for *optional* defaults.
- if you dont set *any* of the values under that pointer, then you take the value from the `defaultConfig`
- if you set just `--pointerName`, it touches the value, and so, you take the default pointer value
- if you set *any* of the parameter under that pointer, you use the `defaultPointerConfig` value as default


Related to https://github.com/containous/traefik/issues/7