### PR TITLE
Fix list on same prefix at the same level 

### DIFF
--- a/kv_mock_test.go
+++ b/kv_mock_test.go
@@ -60,17 +60,11 @@ func (s *Mock) List(prefix string, options *store.ReadOptions) ([]*store.KVPair,
 	if s.Error {
 		return nil, errors.New("error")
 	}
+
 	var kv []*store.KVPair
 	for _, kvPair := range s.KVPairs {
-		if strings.HasPrefix(kvPair.Key, prefix+"/") {
-			if secondSlashIndex := strings.IndexRune(kvPair.Key[len(prefix)+1:], '/'); secondSlashIndex == -1 {
-				kv = append(kv, kvPair)
-			} else {
-				dir := &store.KVPair{
-					Key: kvPair.Key[:secondSlashIndex+len(prefix)+1],
-				}
-				kv = append(kv, dir)
-			}
+		if strings.HasPrefix(kvPair.Key, prefix) {
+			kv = append(kv, kvPair)
 		}
 	}
 	return kv, nil

--- a/kv_mock_test.go
+++ b/kv_mock_test.go
@@ -63,7 +63,7 @@ func (s *Mock) List(prefix string, options *store.ReadOptions) ([]*store.KVPair,
 
 	var kv []*store.KVPair
 	for _, kvPair := range s.KVPairs {
-		if strings.HasPrefix(kvPair.Key, prefix) {
+		if strings.HasPrefix(kvPair.Key, prefix) && kvPair.Key != prefix {
 			kv = append(kv, kvPair)
 		}
 	}

--- a/kv_test.go
+++ b/kv_test.go
@@ -856,6 +856,32 @@ func TestCollateKvPairsShortNameUnexported(t *testing.T) {
 	assert.Exactly(t, expected, kv)
 }
 
+func TestTestListRecursiveWithPrefixSamePrefix(t *testing.T) {
+	kv := &KvSource{
+		&Mock{
+			KVPairs: []*store.KVPair{
+				{Key: "prefix", Value: []byte("")},
+				{Key: "prefix/tls", Value: []byte("")},
+				{Key: "prefix/tls/ca", Value: []byte("v1")},
+				{Key: "prefix/tls/caOptional", Value: []byte("v2")},
+				{Key: "otherprefix/tls/ca", Value: []byte("other")},
+			},
+		},
+		"prefix",
+	}
+	pairs := map[string][]byte{}
+	err := kv.ListRecursive(kv.Prefix, pairs)
+	require.NoError(t, err)
+
+	// Show the issue with the ListRecursive
+	expected := map[string][]byte{
+		"prefix/tls/caOptional": []byte("v2"),
+		// missing the "prefix/tls/ca"
+	}
+
+	assert.Exactly(t, expected, pairs)
+}
+
 func TestListRecursive5Levels(t *testing.T) {
 	kv := &KvSource{
 		&Mock{

--- a/kv_test.go
+++ b/kv_test.go
@@ -798,9 +798,7 @@ func TestStoreConfigEmbeddedSquash(t *testing.T) {
 		"prefix/vfoo": "toto",
 	}
 
-	result := map[string][]byte{}
-
-	err = kv.FetchValuedPairWithPrefix("prefix", result)
+	result, err := kv.ListValuedPairWithPrefix("prefix")
 	require.NoError(t, err)
 
 	assert.Len(t, result, len(expected))
@@ -857,43 +855,216 @@ func TestCollateKvPairsShortNameUnexported(t *testing.T) {
 	assert.Exactly(t, expected, kv)
 }
 
-func TestListRecursiveWithUnknownPrefix(t *testing.T) {
-	kv := &KvSource{
-		&Mock{
-			Error: false,
-			KVPairs: []*store.KVPair{
-				{Key: "prefix/l1", Value: []byte("")},
+func TestListRecursive(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		store    store.Store
+		expected map[string][]byte
+	}{
+		{
+			desc: "With unknown prefix",
+			store: &Mock{
+				Error: false,
+				KVPairs: []*store.KVPair{
+					{Key: "prefix/l1", Value: []byte("")},
+				},
+				WatchTreeMethod: nil,
+				ListError:       store.ErrKeyNotFound,
 			},
-			WatchTreeMethod: nil,
-			ListError:       store.ErrKeyNotFound,
+			expected: map[string][]byte{},
 		},
-		"prefix",
+		{
+			desc: "recursive 5 levels",
+			store: &Mock{
+				KVPairs: []*store.KVPair{
+					{Key: "prefix/l1", Value: []byte("level1")},
+					{Key: "prefix/d1/l1", Value: []byte("level2")},
+					{Key: "prefix/d1/l2", Value: []byte("level2")},
+					{Key: "prefix/d2/d1/l1", Value: []byte("level3")},
+					{Key: "prefix/d3/d2/d1/d1/d1", Value: []byte("level5")},
+				},
+			},
+			expected: map[string][]byte{
+				"prefix/l1":             []byte("level1"),
+				"prefix/d1/l1":          []byte("level2"),
+				"prefix/d1/l2":          []byte("level2"),
+				"prefix/d2/d1/l1":       []byte("level3"),
+				"prefix/d3/d2/d1/d1/d1": []byte("level5"),
+			},
+		},
+		{
+			desc: "recursive empty",
+			store: &Mock{
+				KVPairs: []*store.KVPair{},
+			},
+			expected: map[string][]byte{},
+		},
+		{
+			desc: "same prefix",
+			store: &Mock{
+				KVPairs: []*store.KVPair{
+					{Key: "prefix", Value: []byte("")},
+					{Key: "prefix/tls", Value: []byte("")},
+					{Key: "prefix/tls/ca", Value: []byte("v1")},
+					{Key: "prefix/tls/caOptional", Value: []byte("v2")},
+					{Key: "otherprefix/tls/ca", Value: []byte("other")},
+				},
+			},
+			expected: map[string][]byte{
+				"prefix/tls/caOptional": []byte("v2"),
+				// missing the "prefix/tls/ca"
+			},
+		},
 	}
-	pairs := map[string][]byte{}
-	err := kv.ListRecursive(kv.Prefix, pairs)
-	require.NoError(t, err)
-	assert.Len(t, pairs, 0)
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			kv := &KvSource{
+				Store:  test.store,
+				Prefix: "prefix",
+			}
+
+			pairs := map[string][]byte{}
+			err := kv.ListRecursive(kv.Prefix, pairs)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, pairs)
+		})
+	}
 }
 
-func TestListRecursiveWithGetError(t *testing.T) {
-	myError := errors.New("a GET error")
-	kv := &KvSource{
-		&Mock{
-			GetError: myError,
-			KVPairs: []*store.KVPair{
-				{Key: "prefix/l1", Value: []byte("")},
+func TestListRecursive_Error(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		store    store.Store
+		expected string
+	}{
+		{
+			desc: "get error",
+			store: &KvSource{
+				Store: &Mock{
+					GetError: errors.New("a GET error"),
+					KVPairs: []*store.KVPair{
+						{Key: "prefix/l1", Value: []byte("")},
+					},
+					WatchTreeMethod: nil,
+				},
 			},
-			WatchTreeMethod: nil,
+			expected: "a GET error",
 		},
-		"prefix",
+		{
+			desc: "list Error",
+			store: &Mock{
+				ListError: errors.New("another error"),
+				KVPairs: []*store.KVPair{
+					{Key: "prefix/l1", Value: []byte("")},
+				},
+				WatchTreeMethod: nil,
+			},
+			expected: "another error",
+		},
 	}
-	pairs := map[string][]byte{}
-	err := kv.ListRecursive(kv.Prefix, pairs)
-	assert.Equal(t, err, myError)
-	assert.Len(t, pairs, 0)
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			kv := &KvSource{Store: test.store, Prefix: "prefix"}
+
+			pairs := map[string][]byte{}
+			err := kv.ListRecursive(kv.Prefix, pairs)
+			assert.EqualError(t, err, test.expected)
+			assert.Len(t, pairs, 0)
+		})
+	}
 }
 
-func TestListRecursiveWithError(t *testing.T) {
+func TestListValuedPairWithPrefix(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		store    store.Store
+		expected map[string][]byte
+	}{
+		{
+			desc: "with unknown prefix",
+			store: &Mock{
+				Error: false,
+				KVPairs: []*store.KVPair{
+					{Key: "prefix/l1", Value: []byte("")},
+				},
+				WatchTreeMethod: nil,
+				ListError:       store.ErrKeyNotFound,
+			},
+			expected: map[string][]byte{},
+		},
+		{
+			desc: "with prefix 5 levels",
+			store: &Mock{
+				KVPairs: []*store.KVPair{
+					{Key: "prefix/", Value: []byte("")},
+					{Key: "prefix/l1", Value: []byte("level1")},
+					{Key: "prefix/d1/l1", Value: []byte("level2")},
+					{Key: "prefix/d1/l2", Value: []byte("level2")},
+					{Key: "prefix/d2/d1/l1", Value: []byte("level3")},
+					{Key: "prefix/d3/d2/d1/d1/d1", Value: []byte("level5")},
+				},
+			},
+			expected: map[string][]byte{
+				"prefix/l1":             []byte("level1"),
+				"prefix/d1/l1":          []byte("level2"),
+				"prefix/d1/l2":          []byte("level2"),
+				"prefix/d2/d1/l1":       []byte("level3"),
+				"prefix/d3/d2/d1/d1/d1": []byte("level5"),
+			},
+		},
+		{
+			desc: "with prefix same prefix",
+			store: &Mock{
+				KVPairs: []*store.KVPair{
+					{Key: "prefix", Value: []byte("")},
+					{Key: "prefix/tls", Value: []byte("")},
+					{Key: "prefix/tls/ca", Value: []byte("v1")},
+					{Key: "prefix/tls/caOptional", Value: []byte("v2")},
+					{Key: "otherprefix/tls/ca", Value: []byte("other")},
+				},
+			},
+			expected: map[string][]byte{
+				"prefix/tls/ca":         []byte("v1"),
+				"prefix/tls/caOptional": []byte("v2"),
+			},
+		},
+		{
+			desc: "TestFetchValuedPairWithPrefixEmpty",
+			store: &Mock{
+				KVPairs: []*store.KVPair{},
+			},
+			expected: map[string][]byte{},
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			kv := &KvSource{
+				Store:  test.store,
+				Prefix: "prefix",
+			}
+
+			pairs, err := kv.ListValuedPairWithPrefix(kv.Prefix)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, pairs)
+		})
+	}
+}
+
+func TestListValuedPairWithPrefix_Error(t *testing.T) {
 	kv := &KvSource{
 		&Mock{
 			ListError: errors.New("another error"),
@@ -904,189 +1075,10 @@ func TestListRecursiveWithError(t *testing.T) {
 		},
 		"prefix",
 	}
-	pairs := map[string][]byte{}
-	err := kv.ListRecursive(kv.Prefix, pairs)
+
+	pairs, err := kv.ListValuedPairWithPrefix(kv.Prefix)
 	assert.NotNil(t, err)
 	assert.Len(t, pairs, 0)
-}
-
-func TestTestListRecursiveWithPrefixSamePrefix(t *testing.T) {
-	kv := &KvSource{
-		&Mock{
-			KVPairs: []*store.KVPair{
-				{Key: "prefix", Value: []byte("")},
-				{Key: "prefix/tls", Value: []byte("")},
-				{Key: "prefix/tls/ca", Value: []byte("v1")},
-				{Key: "prefix/tls/caOptional", Value: []byte("v2")},
-				{Key: "otherprefix/tls/ca", Value: []byte("other")},
-			},
-		},
-		"prefix",
-	}
-	pairs := map[string][]byte{}
-	err := kv.ListRecursive(kv.Prefix, pairs)
-	require.NoError(t, err)
-
-	// Show the issue with the ListRecursive
-	expected := map[string][]byte{
-		"prefix/tls/caOptional": []byte("v2"),
-		// missing the "prefix/tls/ca"
-	}
-
-	assert.Exactly(t, expected, pairs)
-}
-
-func TestListRecursive5Levels(t *testing.T) {
-	kv := &KvSource{
-		&Mock{
-			KVPairs: []*store.KVPair{
-				{Key: "prefix/l1", Value: []byte("level1")},
-				{Key: "prefix/d1/l1", Value: []byte("level2")},
-				{Key: "prefix/d1/l2", Value: []byte("level2")},
-				{Key: "prefix/d2/d1/l1", Value: []byte("level3")},
-				{Key: "prefix/d3/d2/d1/d1/d1", Value: []byte("level5")},
-			},
-		},
-		"prefix",
-	}
-	pairs := map[string][]byte{}
-	err := kv.ListRecursive(kv.Prefix, pairs)
-	require.NoError(t, err)
-
-	expected := map[string][]byte{
-		"prefix/l1":             []byte("level1"),
-		"prefix/d1/l1":          []byte("level2"),
-		"prefix/d1/l2":          []byte("level2"),
-		"prefix/d2/d1/l1":       []byte("level3"),
-		"prefix/d3/d2/d1/d1/d1": []byte("level5"),
-	}
-
-	assert.Exactly(t, expected, pairs)
-}
-
-func TestListRecursiveEmpty(t *testing.T) {
-	kv := &KvSource{
-		&Mock{
-			KVPairs: []*store.KVPair{},
-		},
-		"prefix",
-	}
-
-	pairs := map[string][]byte{}
-
-	err := kv.ListRecursive(kv.Prefix, pairs)
-	require.NoError(t, err)
-
-	expected := map[string][]byte{}
-
-	assert.Exactly(t, expected, pairs)
-}
-
-func TestFetchValuedPairWithUnknownPrefix(t *testing.T) {
-	kv := &KvSource{
-		&Mock{
-			Error: false,
-			KVPairs: []*store.KVPair{
-				{Key: "prefix/l1", Value: []byte("")},
-			},
-			WatchTreeMethod: nil,
-			ListError:       store.ErrKeyNotFound,
-		},
-		"prefix",
-	}
-	pairs := map[string][]byte{}
-	err := kv.FetchValuedPairWithPrefix(kv.Prefix, pairs)
-	require.NoError(t, err)
-	assert.Len(t, pairs, 0)
-}
-
-func TestFetchValuedPairWithError(t *testing.T) {
-	kv := &KvSource{
-		&Mock{
-			ListError: errors.New("another error"),
-			KVPairs: []*store.KVPair{
-				{Key: "prefix/l1", Value: []byte("")},
-			},
-			WatchTreeMethod: nil,
-		},
-		"prefix",
-	}
-	pairs := map[string][]byte{}
-	err := kv.FetchValuedPairWithPrefix(kv.Prefix, pairs)
-	assert.NotNil(t, err)
-	assert.Len(t, pairs, 0)
-}
-
-func TestFetchValuedPairWithPrefix5Levels(t *testing.T) {
-	kv := &KvSource{
-		&Mock{
-			KVPairs: []*store.KVPair{
-				{Key: "prefix/", Value: []byte("")},
-				{Key: "prefix/l1", Value: []byte("level1")},
-				{Key: "prefix/d1/l1", Value: []byte("level2")},
-				{Key: "prefix/d1/l2", Value: []byte("level2")},
-				{Key: "prefix/d2/d1/l1", Value: []byte("level3")},
-				{Key: "prefix/d3/d2/d1/d1/d1", Value: []byte("level5")},
-			},
-		},
-		"prefix",
-	}
-	pairs := map[string][]byte{}
-	err := kv.FetchValuedPairWithPrefix(kv.Prefix, pairs)
-	require.NoError(t, err)
-
-	expected := map[string][]byte{
-		"prefix/l1":             []byte("level1"),
-		"prefix/d1/l1":          []byte("level2"),
-		"prefix/d1/l2":          []byte("level2"),
-		"prefix/d2/d1/l1":       []byte("level3"),
-		"prefix/d3/d2/d1/d1/d1": []byte("level5"),
-	}
-
-	assert.Exactly(t, expected, pairs)
-}
-
-func TestFetchValuedPairWithPrefixSamePrefix(t *testing.T) {
-	kv := &KvSource{
-		&Mock{
-			KVPairs: []*store.KVPair{
-				{Key: "prefix", Value: []byte("")},
-				{Key: "prefix/tls", Value: []byte("")},
-				{Key: "prefix/tls/ca", Value: []byte("v1")},
-				{Key: "prefix/tls/caOptional", Value: []byte("v2")},
-				{Key: "otherprefix/tls/ca", Value: []byte("other")},
-			},
-		},
-		"prefix",
-	}
-	pairs := map[string][]byte{}
-	err := kv.FetchValuedPairWithPrefix(kv.Prefix, pairs)
-	require.NoError(t, err)
-
-	expected := map[string][]byte{
-		"prefix/tls/ca":         []byte("v1"),
-		"prefix/tls/caOptional": []byte("v2"),
-	}
-
-	assert.Exactly(t, expected, pairs)
-}
-
-func TestFetchValuedPairWithPrefixEmpty(t *testing.T) {
-	kv := &KvSource{
-		&Mock{
-			KVPairs: []*store.KVPair{},
-		},
-		"prefix",
-	}
-
-	pairs := map[string][]byte{}
-
-	err := kv.FetchValuedPairWithPrefix(kv.Prefix, pairs)
-	require.NoError(t, err)
-
-	expected := map[string][]byte{}
-
-	assert.Exactly(t, expected, pairs)
 }
 
 func TestConvertPairs5Levels(t *testing.T) {

--- a/kv_test.go
+++ b/kv_test.go
@@ -3,12 +3,11 @@ package staert
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
-
-	"errors"
 
 	"github.com/abronan/valkeyrie/store"
 	"github.com/containous/flaeg"


### PR DESCRIPTION
### What does this PR do?
Replace recursive List with an iterative one based on the pair value

Example :

Available keys :
* **prefix/foo** "value1"
* **prefix/foo**Bar "value2"

Actual result
* **prefix/foo**Bar "value2"

Expected result
* **prefix/foo** "value1"
* **prefix/foo**Bar "value2"

When the prefix "prefix/foo" will arrived into the recursive list, its value will not be fetched because will be considered as the parent of "prefix/fooBar" .

Moreover, we have all the key value pairs at the first list call, so we already have all the needed data.
The new version returns only the valued pairs.

### Motivation
Fix issue for list on same prefix at the same level (prefix/a, prefix/ab)
Related to https://github.com/containous/traefik/issues/3249 

### More

 - [x] Added/updated tests
