### PR TITLE
Return an error when the configuration file could not be found on disk

### DIFF
--- a/toml.go
+++ b/toml.go
@@ -1,6 +1,7 @@
 package staert
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +35,7 @@ func (ts *TomlSource) ConfigFileUsed() string {
 func (ts *TomlSource) Parse(cmd *flaeg.Command) (*flaeg.Command, error) {
 	ts.fullPath = findFile(ts.filename, ts.dirNFullPath)
 	if len(ts.fullPath) < 2 {
-		return cmd, nil
+		return cmd, fmt.Errorf("unable to find config file on disk")
 	}
 
 	metadata, err := toml.DecodeFile(ts.fullPath, cmd.Config)

--- a/toml_test.go
+++ b/toml_test.go
@@ -71,8 +71,8 @@ func TestTomlSource_Parse_FileNotFound(t *testing.T) {
 	}
 
 	command, err := src.Parse(cmd)
-	require.NoError(t, err)
 
+	assert.Error(t, err, "unable to find config file on disk")
 	assert.Exactly(t, cmd, command)
 }
 


### PR DESCRIPTION
Heya :wave: 

This is an attempt to fix [an open issue at Traefik](https://github.com/containous/traefik/issues/2927). I realize that this is probably not the way this issue should be fixed since I've changed the behavior of the `Parse` method so I'm using the PR to seek some guidance. :see_no_evil:

I would love to hear your thoughts on this.

Thanks!

