### PR TITLE
dep: remove master constraint on mapstructure

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,10 +31,6 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/mitchellh/mapstructure"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/abronan/valkeyrie"
 
 [[constraint]]


### PR DESCRIPTION
The goal is to not force `mapstructure` to be constraint to master and thus provide a cleaner fix for https://github.com/containous/traefik/pull/4320

Signed-off-by: Vincent Demeester <vincent@sbr.pm>