### PR TITLE
Add support for replacing an existing kv prefix with a new set

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We developed [Flæg](https://github.com/containous/flaeg) and Stært in order to
 - Three native sources :
 	- Command line arguments using [Flæg](https://github.com/containous/flaeg) package
 	- TOML config file using [TOML](http://github.com/BurntSushi/toml) package
-	- [Key-Value Store](#kvstore) using [libkv](https://github.com/docker/libkv) and [mapstructure](https://github.com/mitchellh/mapstructure) packages
+	- [Key-Value Store](#kvstore) using [valkeyrie](https://github.com/abronan/valkeyrie) and [mapstructure](https://github.com/mitchellh/mapstructure) packages
 - An interface to add your own sources
 - Handle pointers field :
 	- You can give a structure of default values for pointers
@@ -211,7 +211,7 @@ Thank you [@debovema](https://github.com/debovema) for this work :)
 ## KvStore
 
 As with Flæg and TOML sources, the configuration structure can be loaded from a Key-Value Store.
-The package [libkv](https://github.com/docker/libkv) provides connection to many KV Store like `Consul`, `Etcd` or `Zookeeper`.
+The package [valkeyrie](https://github.com/abronan/valkeyrie) provides connection to many KV Store like `Consul`, `Etcd` or `Zookeeper`.
 
 The whole configuration structure is stored, using architecture like this pattern:
 

--- a/kv_mock_test.go
+++ b/kv_mock_test.go
@@ -40,7 +40,16 @@ func (s *Mock) Get(key string, options *store.ReadOptions) (*store.KVPair, error
 }
 
 func (s *Mock) Delete(key string) error {
-	return errors.New("delete not supported")
+	pairs := make([]*store.KVPair, 0)
+	for _, pair := range s.KVPairs {
+		if pair.Key != key {
+			pairs = append(pairs, pair)
+		}
+	}
+
+	s.KVPairs = pairs
+
+	return nil
 }
 
 // Exists mock


### PR DESCRIPTION
This PR adds a new method `ReplaceConfig` that will remove any keys (for the source's prefix) that are not present in the new config. This is primarily to solve https://github.com/containous/traefik/issues/2093 – by adding this, we can make Traefik use `ReplaceConfig` instead.

This will have the desired effect of removing any stale keys (that can lead to Traefik picking up config that the user thinks is not present), while maintaining any existing keys.